### PR TITLE
feat: add route to increment access count for Wikipedia documents

### DIFF
--- a/back-end/api.http
+++ b/back-end/api.http
@@ -3,12 +3,16 @@
 GET http://localhost:3333/wikipedia/search?query=quadratic+equation&page=1&pageSize=10
 
 ###
-GET http://localhost:3333/wikipedia/9
+GET http://localhost:3333/wikipedia/332
 
 ###
 GET http://localhost:3333/wikipedia/mostViews/9
 
 ###
+GET http://localhost:3333/wikipedia/increment/332
+
+###
+
 POST http://localhost:3333/signup
 Content-Type: application/json
 

--- a/back-end/src/controllers/elasticsearch.controller.ts
+++ b/back-end/src/controllers/elasticsearch.controller.ts
@@ -1,7 +1,8 @@
 import {
   getDocsWikipediaService,
   getDocByIdWikipediaService,
-  getMostViewedDocsWikipediaService
+  getMostViewedDocsWikipediaService,
+  addNumViewDocService
 } from '../services/elasticsearch.service'
 
 export const getDocsWikipediaController = async (req, res) => {
@@ -42,6 +43,20 @@ export const getMostViewedDocsWikipediaController = async (req, res) => {
       return res.status(400).send({ message: 'Invalid params' })
     }
     console.error('Internal server error', error)
+    return res.status(500).send({ message: 'Internal server error' })
+  }
+}
+
+export const addNumViewDocController = async (req, res) => {
+  const { id } = req.params
+  try {
+    const result = await addNumViewDocService(id)
+    return res.status(204).send()
+  } catch (error) {
+    if (error instanceof Error && error.message === 'document not found') {
+      return res.status(404).send({ message: 'document not found' })
+    }
+    console.error(error)
     return res.status(500).send({ message: 'Internal server error' })
   }
 }

--- a/back-end/src/models/config.schema.ts
+++ b/back-end/src/models/config.schema.ts
@@ -1,72 +1,72 @@
 // esse schema contem todos as preferencias do usuario
-import { Schema } from "mongoose";
-import mongoose from "mongoose";
-
+import { Schema } from 'mongoose'
+import mongoose from 'mongoose'
 
 // tipagem do schema folders
 interface InterfaceFolders {
-    folderName: string,
-    wikipages: number [];
+  folderName: string
+  wikipages: number[]
 }
 
-//tipagem do schema user 
-export interface InterfaceConfig{
-    backgroundImage: string,    
-    favorite: [ string ],
-    fontFamily: string,
-    folders: InterfaceFolders[],
-    outputMethod: 'sameScreen' | 'diffScreen', // sameScreen na mesma tela do inicio
-                                               // diffScreen redireciona para tela de resultados  
-    quickAccess: [ string ],
-    themeColor: string
+//tipagem do schema user
+export interface InterfaceConfig {
+  backgroundImage: string
+  favorite: [string]
+  fontFamily: string
+  folders: InterfaceFolders[]
+  outputMethod: 'sameScreen' | 'diffScreen' // sameScreen na mesma tela do inicio
+  // diffScreen redireciona para tela de resultados
+  quickAccess: [string]
+  themeColor: string
 }
 
-const folderSchema = new Schema <InterfaceFolders>(
-    {
-        folderName: {
-            type: String,
-            required: false
-        },
-        wikipages: {
-            type: [ Number ],
-            default: []
-        }
+const folderSchema = new Schema<InterfaceFolders>(
+  {
+    folderName: {
+      type: String,
+      required: false
     },
-    { _id : false }
+    wikipages: {
+      type: [Number],
+      default: []
+    }
+  },
+  { _id: false }
 )
 
 export const configSchema = new Schema<InterfaceConfig>( // garantindo que o schema seja equivalente a interface
-    {
-        backgroundImage: {
-            type: String,
-            default: ''
-        },
-        favorite: { // lista
-            type: [ String ],
-            default: () => []
-        },
-        fontFamily: {
-            type: String,
-            default: ''
-        },
-        folders: { // vai ser uma lista de objetos. dentro de folders -> folder -> wikipages (id : inteiro)
-            type: [ folderSchema ],
-            default: []
-        },
-        outputMethod: {
-            type: String,
-            enum: ['sameScreen', 'diffScreen'],
-            default: 'diffScreen'
-        },
-        quickAccess: {
-            type: [ String ],
-            default: () => []
-        },
-        themeColor: {
-            type: String,
-            default: ''
-        }
+  {
+    backgroundImage: {
+      type: String,
+      default: ''
     },
-    { _id: false }, // nao precisamos de um id para config ja vai estar importado em user
+    favorite: {
+      // lista
+      type: [String],
+      default: () => []
+    },
+    fontFamily: {
+      type: String,
+      default: ''
+    },
+    folders: {
+      // vai ser uma lista de objetos. dentro de folders -> folder -> wikipages (id : inteiro)
+      type: [folderSchema],
+      default: []
+    },
+    outputMethod: {
+      type: String,
+      enum: ['sameScreen', 'diffScreen'],
+      default: 'diffScreen'
+    },
+    quickAccess: {
+      type: [String],
+      default: () => []
+    },
+    themeColor: {
+      type: String,
+      default: ''
+    }
+  },
+  { _id: false } // nao precisamos de um id para config ja vai estar importado em user
 )
-

--- a/back-end/src/routes/elasticsearch.route.ts
+++ b/back-end/src/routes/elasticsearch.route.ts
@@ -2,7 +2,8 @@ import { z } from 'zod'
 import {
   getDocsWikipediaController,
   getDocByIdWikipediaController,
-  getMostViewedDocsWikipediaController
+  getMostViewedDocsWikipediaController,
+  addNumViewDocController
 } from '../controllers/elasticsearch.controller'
 import { resultSchema } from '../schemas/elasticsearch.schema'
 
@@ -95,5 +96,34 @@ export function searchRoutes(app) {
       }
     },
     getMostViewedDocsWikipediaController
+  )
+
+  app.get(
+    '/wikipedia/increment/:id',
+    {
+      schema: {
+        summary: 'Increment the view count of a Wikipedia document',
+        description:
+          'This route increments the access_count field of a Wikipedia document stored in Elasticsearch based on the provided ID.',
+        tags: ['Wikipedia', 'ElasticSearch'],
+        params: z.object({
+          id: z.string()
+        }),
+        response: {
+          204: {
+            description:
+              'View count successfully incremented (no content returned)'
+          },
+          404: z.object({
+            message: z.string()
+          }),
+          500: z.object({
+            message: z.string(),
+            error: z.string()
+          })
+        }
+      }
+    },
+    addNumViewDocController
   )
 }

--- a/back-end/src/server.ts
+++ b/back-end/src/server.ts
@@ -16,16 +16,16 @@ import { profile } from './routes/profile'
 
 // criando conexao com mongo
 
-import mongoose from 'mongoose'
+// import mongoose from 'mongoose'
 
-const uri = "mongodb://localhost:27017/elastic_db"
+// const uri = "mongodb://localhost:27017/elastic_db"
 
-mongoose.connect ( uri ).then(() => console.log( 'MongoDB conectado em ', uri ))
-                        .catch( err => {
-                          console.log( "Erro na conexao com MongoDB", err )
-                          process.exit(1)
-                        });
-                      
+// mongoose.connect ( uri ).then(() => console.log( 'MongoDB conectado em ', uri ))
+//                         .catch( err => {
+//                           console.log( "Erro na conexao com MongoDB", err )
+//                           process.exit(1)
+//                         });
+
 // ===============
 
 dotenv.config()

--- a/back-end/src/services/elasticsearch.service.ts
+++ b/back-end/src/services/elasticsearch.service.ts
@@ -58,8 +58,6 @@ export const getDocByIdWikipediaService = async (id: string) => {
     const _id = result._id
     const resultSource = result._source as WikipediaDocument
 
-    addNumView(id)
-
     return {
       _id,
       title: resultSource.title,
@@ -104,6 +102,17 @@ export const getMostViewedDocsWikipediaService = async (limit: number) => {
     _id: item._id,
     ...item._source
   }))
+}
+
+export const addNumViewDocService = async (id: string) => {
+  try {
+    const response = await addNumView(id)
+    return response
+  } catch (error) {
+    if (error instanceof errors.ResponseError && error.statusCode === 404) {
+      throw new Error('document not found')
+    }
+  }
 }
 
 export const addNumView = async (id: string) => {

--- a/front-end/src/api-client/elastic.ts
+++ b/front-end/src/api-client/elastic.ts
@@ -30,3 +30,7 @@ export const searchDocs = async (
   )
   return response.data
 }
+
+export const addNumViewDoc = async (id: string) => {
+  await API.get(`/wikipedia/increment/${id}`)
+}

--- a/front-end/src/components/MathTopics.tsx
+++ b/front-end/src/components/MathTopics.tsx
@@ -2,6 +2,7 @@ import { Search } from 'lucide-react'
 import { Pagination } from './Pagination'
 import { useEffect, useState } from 'react'
 import { type Result, getMostViewedDocs } from '../api-client/elastic'
+import { Link } from 'react-router-dom'
 
 export const MathTopics = () => {
   const [page, setPage] = useState(1)
@@ -31,7 +32,9 @@ export const MathTopics = () => {
               <div className="math-topics__card-item">
                 <div className="math-topics__card-item--header">
                   <p>{document.title}</p>
-                  <Search className="math-topics__card-item--search" />
+                  <Link to={`/wiki/${document.title}`}>
+                    <Search className="math-topics__card-item--search" />
+                  </Link>
                 </div>
                 <div className="math-topics__card-item--text">
                   <p>{document.content}</p>

--- a/front-end/src/components/ResultDocument.tsx
+++ b/front-end/src/components/ResultDocument.tsx
@@ -1,13 +1,20 @@
 import { ArrowRight } from 'lucide-react'
 import wiki from '../assets/wiki_icon.png'
-import type { Result } from '../api-client/elastic'
-import { Link } from 'react-router-dom'
+import { addNumViewDoc, type Result } from '../api-client/elastic'
+import { Link, useNavigate } from 'react-router-dom'
 
 type ResultDocumentProps = {
   result: Result
 }
 
 export const ResultDocument = ({ result }: ResultDocumentProps) => {
+  const navigate = useNavigate()
+
+  const handleClick = async () => {
+    await addNumViewDoc(result._id.toString())
+    navigate(`/wiki/${result.title}`)
+  }
+
   return (
     <div className="results__item">
       <div className="results__item-header">
@@ -24,12 +31,10 @@ export const ResultDocument = ({ result }: ResultDocumentProps) => {
       <div className="results__item--content">
         <p>{result.content}</p>
       </div>
-      <Link to={`/wiki/${result.title}`}>
-        <div className="results__item--go-link">
-          <p>Go</p>
-          <ArrowRight size={13} />
-        </div>
-      </Link>
+      <div className="results__item--go-link" onClick={handleClick}>
+        <p>Go</p>
+        <ArrowRight size={13} />
+      </div>
     </div>
   )
 }

--- a/front-end/src/index.css
+++ b/front-end/src/index.css
@@ -1177,7 +1177,8 @@ body.dark-theme .wiki__content div,
 body.dark-theme .wiki__content dd,
 body.dark-theme .wiki__content li,
 body.dark-theme .wiki__content ul,
-body.dark-theme .wiki__content figcaption {
+body.dark-theme .wiki__content figcaption,
+body.dark-theme .wiki__content pre {
   background-color: var(--background-dark) !important;
   color: white !important;
 }


### PR DESCRIPTION
This pull request introduces a new backend route to increment the access_count of a Wikipedia document stored in Elasticsearch. This is used to track the most viewed documents within the application.

📌 Changes:
Created GET /wikipedia/increment/:id route to increment the document’s access_count.

Removed access count logic from getById service to decouple concerns (retrieval vs. analytics).

Created dedicated controller and service for the increment operation.

Integrated the new route into the frontend: now, when a user clicks on a document link, the access_count is incremented via an API call before navigation.

✅ Reason for the change:
Previously, the getById method was responsible for increasing the view count, but this was not being triggered when documents were opened directly using Wikipedia’s HTML API. This PR introduces a clean and explicit way to track views without unnecessary document fetches.