### PR TITLE
feat(user): add GET /users/me/folders to return user's folders

### DIFF
--- a/back-end/src/controllers/folder.controller.ts
+++ b/back-end/src/controllers/folder.controller.ts
@@ -1,0 +1,16 @@
+import { getFoldersService } from '../services/folder.service'
+
+export const getFoldersController = async (request, reply) => {
+  const id = request.user?.id
+
+  try {
+    const folders = await getFoldersService(id)
+    return reply.code(200).send(folders)
+  } catch (error) {
+    if (error instanceof Error && error.message === 'User not found') {
+      return reply.code(404).send({ message: 'User not found' })
+    }
+    console.error(error)
+    return reply.code(500).send({ message: 'User not found' })
+  }
+}

--- a/back-end/src/routes/folder.route.ts
+++ b/back-end/src/routes/folder.route.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod'
+import { getFoldersController } from '../controllers/folder.controller'
+import { authenticateToken } from '../services/registerAuthServer.service'
+
+export function folderRoute(app) {
+  app.get(
+    '/users/me/folders',
+    {
+      preHandler: authenticateToken,
+      schema: {
+        summary: '',
+        description: '',
+        tags: [''],
+        response: {
+          200: z.array(
+            z.object({
+              folderName: z.string(),
+              list: z.array(z.number())
+            })
+          ),
+          404: z.object({
+            message: z.string()
+          }),
+          500: z.object({
+            message: z.string(),
+            error: z.string()
+          })
+        }
+      }
+    },
+    getFoldersController
+  )
+}

--- a/back-end/src/server.ts
+++ b/back-end/src/server.ts
@@ -16,6 +16,7 @@ import { connectDb } from './config/connect'
 import { historyRoute } from './routes/hisory.route'
 import { favoriteRoute } from './routes/favorite.route'
 import { shortcutRoute } from './routes/shortcut.route'
+import { folderRoute } from './routes/folder.route'
 
 // criando conexao com mongo
 
@@ -30,6 +31,7 @@ app.register(authServer)
 app.register(historyRoute)
 app.register(favoriteRoute)
 app.register(shortcutRoute)
+app.register(folderRoute)
 
 app.setValidatorCompiler(validatorCompiler)
 app.setSerializerCompiler(serializerCompiler)

--- a/back-end/src/services/folder.service.ts
+++ b/back-end/src/services/folder.service.ts
@@ -1,0 +1,7 @@
+import { getUserById } from '../repository/user.repository'
+
+export const getFoldersService = async (id: string) => {
+  const user = await getUserById(id)
+  if (!user) throw new Error('User not found')
+  return user.config.folders
+}


### PR DESCRIPTION
📄 Description
This pull request introduces a new authenticated route that allows users to retrieve their folder list.

🔧 Changes
Implemented getFoldersService to fetch folders linked to the authenticated user

Added controller and route under /users/me/folders

Retrieves the user ID from the authentication header

✅ Features
Enables users to list all their folders

Folders are tied to the authenticated user

Route supports future enhancements like pagination or filtering

🔒 Authentication
This route is protected. A valid token is required in the Authorization header.