### PR TITLE
feat: add user shortcuts update and fix user update logic to prevent …

### DIFF
--- a/back-end/api.http
+++ b/back-end/api.http
@@ -31,7 +31,7 @@ Content-Type: application/json
 
 ###
 GET http://localhost:3333/user/me
-Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImFkbWluemFkYSIsImlkIjoiNjg0YjZlZjc0OGYyYTU3YTEyMGZlMDJiIiwiaWF0IjoxNzQ5ODUyODY2LCJleHAiOjE3NDk4NTMwNDZ9.N82auDJwrtfhEp52fRyglTRQh1ID8Q4Sr-R89zIyyEo
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImFkbWluemFkYSIsImlkIjoiNjg0YjZlZjc0OGYyYTU3YTEyMGZlMDJiIiwiaWF0IjoxNzQ5OTA0MDk1LCJleHAiOjE3NDk5MDQyNzV9._1xBUbBVy-HfbGfIfkIBc0rp9aP8mNoBUMkJ7pGUwqs
 
 ###
 GET http://localhost:3333/user/search/admin2
@@ -58,11 +58,11 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImFkb
 
 ###
 PATCH http://localhost:3333/users/me/history
-Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImFkbWluemFkYSIsImlkIjoiNjg0YjZlZjc0OGYyYTU3YTEyMGZlMDJiIiwiaWF0IjoxNzQ5ODUyODY2LCJleHAiOjE3NDk4NTMwNDZ9.N82auDJwrtfhEp52fRyglTRQh1ID8Q4Sr-R89zIyyEo
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImFkbWluemFkYSIsImlkIjoiNjg0YjZlZjc0OGYyYTU3YTEyMGZlMDJiIiwiaWF0IjoxNzQ5OTA0NTU4LCJleHAiOjE3NDk5MDQ3Mzh9.PlsqbncJZrUeeYdFS1drrpaP7zeZl2-vpHisaj_k8Ok
 Content-Type: application/json
 
 {
-  "history": [1, 2, 3, 4]
+  "history": [1, 2, 3, 4, 5]
 } 
 
 ###
@@ -71,16 +71,25 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImFkb
 
 ###
 PATCH http://localhost:3333/users/me/favorite
-Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImFkbWluemFkYSIsImlkIjoiNjg0YjZlZjc0OGYyYTU3YTEyMGZlMDJiIiwiaWF0IjoxNzQ5ODU5MTI3LCJleHAiOjE3NDk4NTkzMDd9.twhnLp5eyzTRQ_xMYF5zcNKkn16JmADbYF5eN245SRM
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImFkbWluemFkYSIsImlkIjoiNjg0YjZlZjc0OGYyYTU3YTEyMGZlMDJiIiwiaWF0IjoxNzQ5OTA0NTU4LCJleHAiOjE3NDk5MDQ3Mzh9.PlsqbncJZrUeeYdFS1drrpaP7zeZl2-vpHisaj_k8Ok
 Content-Type: application/json
 
 {
-  "favorite": [1, 2, 3, 4]
+  "favorite": [1, 2, 3, 4, 9]
 } 
 
 ###
 GET http://localhost:3333/users/me/shortcuts
 Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImFkbWluMiIsImlkIjoiNjgzODY4YWJlNDRkM2UzNjk1M2U4NmJkIiwiaWF0IjoxNzQ5NDc1MjMxLCJleHAiOjE3NDk0NzU0MTF9.S3Fqw28mzboU8PvAe9OAJ0U32rlkVKJvtCJXVlcWc8Y
+
+###
+PATCH http://localhost:3333/users/me/shortcuts
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImFkbWluemFkYSIsImlkIjoiNjg0YjZlZjc0OGYyYTU3YTEyMGZlMDJiIiwiaWF0IjoxNzQ5OTA0NTU4LCJleHAiOjE3NDk5MDQ3Mzh9.PlsqbncJZrUeeYdFS1drrpaP7zeZl2-vpHisaj_k8Ok
+Content-Type: application/json
+
+{
+  "quickAccess": [1, 4, 5, 10]
+}
 
 ###
 GET http://localhost:3333/users/me/folders

--- a/back-end/src/controllers/shortcut.controller.ts
+++ b/back-end/src/controllers/shortcut.controller.ts
@@ -1,15 +1,34 @@
-import { getShortcutsService } from '../services/shortcut.service'
+import {
+  getShortcutsService,
+  updateShortcutsService
+} from "../services/shortcut.service";
 
 export const getShortcutsController = async (request, reply) => {
-  const id = request.user?.id
+  const id = request.user?.id;
   try {
-    const shortcuts = await getShortcutsService(id)
-    return reply.code(200).send(shortcuts)
+    const shortcuts = await getShortcutsService(id);
+    return reply.code(200).send(shortcuts);
   } catch (error) {
-    if (error instanceof Error && error.message === 'User not found') {
-      return reply.code(404).send({ message: 'User not found' })
+    if (error instanceof Error && error.message === "User not found") {
+      return reply.code(404).send({ message: "User not found" });
     }
-    console.error(500)
-    return reply.code(500).send({ message: 'internal server error' })
+    console.error(500);
+    return reply.code(500).send({ message: "internal server error" });
   }
-}
+};
+
+export const updateShortcutsController = async (request, reply) => {
+  const id = request.user?.id;
+  const { quickAccess } = request.body;
+
+  try {
+    const newUser = await updateShortcutsService(id, quickAccess);
+    return reply.code(200).send(newUser);
+  } catch (error) {
+    if (error instanceof Error && error.message === "User not found") {
+      return reply.code(404).send({ message: "User not found" });
+    }
+    console.error(error);
+    return reply.code(500).send({ message: "Internal server error" });
+  }
+};

--- a/back-end/src/dto/shortcuts/updateShortcuts.dto.ts
+++ b/back-end/src/dto/shortcuts/updateShortcuts.dto.ts
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const updateShortcutsDto = z.array(z.number());
+
+export type UpdateShortcutsDto = z.infer<typeof updateShortcutsDto>;

--- a/back-end/src/repository/user.repository.ts
+++ b/back-end/src/repository/user.repository.ts
@@ -18,5 +18,9 @@ export const deleteUser = async (id: string) => {
 };
 
 export const updateUser = async (id: string, user: any) => {
-  return await UserSchema.findByIdAndUpdate({ _id: id }, user, { new: true });
+  return await UserSchema.findByIdAndUpdate(
+    { _id: id },
+    { $set: user },
+    { new: true }
+  );
 };

--- a/back-end/src/routes/shortcut.route.ts
+++ b/back-end/src/routes/shortcut.route.ts
@@ -1,6 +1,11 @@
-import { getShortcutsController } from "../controllers/shortcut.controller";
+import {
+  getShortcutsController,
+  updateShortcutsController
+} from "../controllers/shortcut.controller";
 import { z } from "zod";
 import { authenticateToken } from "../services/registerAuthServer.service";
+import { updateShortcutsDto } from "../dto/shortcuts/updateShortcuts.dto";
+import { userSchema } from "../schemas/user.schema";
 
 export function shortcutRoute(app) {
   app.get(
@@ -25,5 +30,31 @@ export function shortcutRoute(app) {
       }
     },
     getShortcutsController
+  );
+
+  app.patch(
+    "/users/me/shortcuts",
+    {
+      preHandler: authenticateToken,
+      schema: {
+        summary: "",
+        description: "",
+        tags: [""],
+        body: z.object({
+          quickAccess: updateShortcutsDto
+        }),
+        response: {
+          200: userSchema,
+          404: z.object({
+            message: z.string()
+          }),
+          500: z.object({
+            message: z.string(),
+            error: z.string()
+          })
+        }
+      }
+    },
+    updateShortcutsController
   );
 }

--- a/back-end/src/services/favorite.service.ts
+++ b/back-end/src/services/favorite.service.ts
@@ -17,8 +17,6 @@ export const updateFavoriteService = async (
   if (!user) throw new Error("User not found");
 
   return await updateUser(id, {
-    config: {
-      favorite: favorite
-    }
+    "config.favorite": favorite
   });
 };

--- a/back-end/src/services/shortcut.service.ts
+++ b/back-end/src/services/shortcut.service.ts
@@ -1,7 +1,20 @@
-import { getUserById } from '../repository/user.repository'
+import { UpdateShortcutsDto } from "../dto/shortcuts/updateShortcuts.dto";
+import { getUserById, updateUser } from "../repository/user.repository";
 
 export const getShortcutsService = async (id: string) => {
-  const user = await getUserById(id)
-  if (!user) throw new Error('User not found')
-  return user.config.quickAccess
-}
+  const user = await getUserById(id);
+  if (!user) throw new Error("User not found");
+  return user.config.quickAccess;
+};
+
+export const updateShortcutsService = async (
+  id: string,
+  shortcuts: UpdateShortcutsDto
+) => {
+  const user = await getUserById(id);
+  if (!user) throw new Error("User not found");
+
+  return await updateUser(id, {
+    "config.quickAccess": shortcuts
+  });
+};


### PR DESCRIPTION
✅ Pull Request description (em inglês):
What I did:

Added the logic to update user shortcuts (shortcuts update endpoint and related service/controller layers).

Fixed a critical issue in the general user update function: previously, updating a user could overwrite the entire user object because the update operation was passing the full object instead of using field-level $set.

Now, the update process explicitly defines which fields to update, preventing accidental data loss.

Why I did it:

To allow users to manage their shortcuts via the API.

To fix a dangerous bug where user updates could unintentionally overwrite unrelated user data.

How to test it:

Test the new shortcuts update endpoint:
→ Send a request with a sample shortcuts array and verify that the user document updates only the shortcuts field.

Test general user updates (other endpoints that use the user update function):
→ Make sure that only the specified fields are being updated and no data is being wiped.