### PR TITLE
feat: add folders update endpoint with controller, service, routes, a…

### DIFF
--- a/back-end/api.http
+++ b/back-end/api.http
@@ -96,6 +96,24 @@ GET http://localhost:3333/users/me/folders
 Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImFkbWluMiIsImlkIjoiNjgzODY4YWJlNDRkM2UzNjk1M2U4NmJkIiwiaWF0IjoxNzQ5NDc2NDM5LCJleHAiOjE3NDk0NzY2MTl9.3361RRJEJqcq6tKxm2oD4-8FNzMToDThIAgbrsLl7E8
 
 ###
+PATCH http://localhost:3333/users/me/folders
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImFkbWluemFkYSIsImlkIjoiNjg0YjZlZjc0OGYyYTU3YTEyMGZlMDJiIiwiaWF0IjoxNzQ5OTA5MTI3LCJleHAiOjE3NDk5MDkzMDd9.jWL66YP9lntvyVp9wy2G5VrnTnQfutDhH81Oz7JTmbQ
+Content-Type: application/json
+
+{
+  "folders": [
+  {
+    "folderName": "favoritos",
+    "wikipages": [1, 2, 3]
+  },
+  {
+    "folderName": "lidos",
+    "wikipages": [1, 10, 61]
+  }
+  ]
+}
+
+###
 GET http://localhost:3333/users/me/general-settings
 Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImFkbWluMiIsImlkIjoiNjgzODY4YWJlNDRkM2UzNjk1M2U4NmJkIiwiaWF0IjoxNzQ5NDc4MTQ3LCJleHAiOjE3NDk0NzgzMjd9.reqi-kPIanNruZaiSCYFo3Zt497sqHgFtR_X7gzPMS0
 

--- a/back-end/src/controllers/folder.controller.ts
+++ b/back-end/src/controllers/folder.controller.ts
@@ -1,16 +1,35 @@
-import { getFoldersService } from '../services/folder.service'
+import {
+  getFoldersService,
+  updateFoldersService
+} from "../services/folder.service";
 
 export const getFoldersController = async (request, reply) => {
-  const id = request.user?.id
+  const id = request.user?.id;
 
   try {
-    const folders = await getFoldersService(id)
-    return reply.code(200).send(folders)
+    const folders = await getFoldersService(id);
+    return reply.code(200).send(folders);
   } catch (error) {
-    if (error instanceof Error && error.message === 'User not found') {
-      return reply.code(404).send({ message: 'User not found' })
+    if (error instanceof Error && error.message === "User not found") {
+      return reply.code(404).send({ message: "User not found" });
     }
-    console.error(error)
-    return reply.code(500).send({ message: 'User not found' })
+    console.error(error);
+    return reply.code(500).send({ message: "User not found" });
   }
-}
+};
+
+export const updateFoldersController = async (request, reply) => {
+  const id = request.user?.id;
+  const { folders } = request.body;
+
+  try {
+    const newUser = await updateFoldersService(id, folders);
+    return reply.code(200).send(newUser);
+  } catch (error) {
+    if (error instanceof Error && error.message === "User not found") {
+      return reply.code(404).send({ message: "User not found" });
+    }
+    console.error(error);
+    return reply.code(500).send({ message: "User not found" });
+  }
+};

--- a/back-end/src/dto/folders/updateFolders.dto.ts
+++ b/back-end/src/dto/folders/updateFolders.dto.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const updateFoldersDto = z.object({
+  folderName: z.string(),
+  wikipages: z.array(z.number())
+});
+
+export type UpdateFoldersDto = z.infer<typeof updateFoldersDto>;

--- a/back-end/src/routes/folder.route.ts
+++ b/back-end/src/routes/folder.route.ts
@@ -1,6 +1,11 @@
 import { z } from "zod";
-import { getFoldersController } from "../controllers/folder.controller";
+import {
+  getFoldersController,
+  updateFoldersController
+} from "../controllers/folder.controller";
 import { authenticateToken } from "../services/registerAuthServer.service";
+import { updateFoldersDto } from "../dto/folders/updateFolders.dto";
+import { userSchema } from "../schemas/user.schema";
 
 export function folderRoute(app) {
   app.get(
@@ -30,5 +35,31 @@ export function folderRoute(app) {
       }
     },
     getFoldersController
+  );
+
+  app.patch(
+    "/users/me/folders",
+    {
+      preHandler: authenticateToken,
+      schema: {
+        summary: "",
+        description: "",
+        tags: [""],
+        body: z.object({
+          folders: z.array(updateFoldersDto)
+        }),
+        response: {
+          200: userSchema,
+          404: z.object({
+            message: z.string()
+          }),
+          500: z.object({
+            message: z.string(),
+            error: z.string()
+          })
+        }
+      }
+    },
+    updateFoldersController
   );
 }

--- a/back-end/src/schemas/user.schema.ts
+++ b/back-end/src/schemas/user.schema.ts
@@ -8,8 +8,8 @@ const configSchema = z.object({
   favorite: z.array(z.number()),
   folders: z.array(
     z.object({
-      foldernName: z.string(),
-      list: z.array(z.number())
+      folderName: z.string(),
+      wikipages: z.array(z.number())
     })
   ),
   quickAccess: z.array(z.number())

--- a/back-end/src/services/folder.service.ts
+++ b/back-end/src/services/folder.service.ts
@@ -1,7 +1,19 @@
-import { getUserById } from '../repository/user.repository'
+import { UpdateFoldersDto } from "../dto/folders/updateFolders.dto";
+import { getUserById, updateUser } from "../repository/user.repository";
 
 export const getFoldersService = async (id: string) => {
-  const user = await getUserById(id)
-  if (!user) throw new Error('User not found')
-  return user.config.folders
-}
+  const user = await getUserById(id);
+  if (!user) throw new Error("User not found");
+  return user.config.folders;
+};
+
+export const updateFoldersService = async (
+  id: string,
+  folders: UpdateFoldersDto
+) => {
+  const user = await getUserById(id);
+  if (!user) throw new Error("User not found");
+  return await updateUser(id, {
+    "config.folders": folders
+  });
+};


### PR DESCRIPTION
✅ Pull Request description (em inglês):
What I did:
Implemented the endpoint to update user folders. This includes:

Creating a new updateFolderDto to validate input.

Adding a new route for updating folders.

Implementing the controller and service logic to handle the folder update.

The folders field is a list of objects, each containing a folderName and an array of saved documents.

Why I did it:
To allow users to organize and update their saved folders and documents structure via the API.

How to test it:

Send a request to the new folders update endpoint with a payload like:

```json
{
  "folders": [
    {
      "folderName": "Work",
      "wikipages": [1, 4]
    },
    {
      "folderName": "Personal",
       "wikipages": [10, 430]
    }
  ]
}
```
