### PR TITLE
refactor: separate user array update logic and add type-based control…

### DIFF
--- a/back-end/api.http
+++ b/back-end/api.http
@@ -58,11 +58,12 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImFkb
 
 ###
 PATCH http://localhost:3333/users/me/history
-Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImFkbWluemFkYSIsImlkIjoiNjg0YjZlZjc0OGYyYTU3YTEyMGZlMDJiIiwiaWF0IjoxNzQ5OTA0NTU4LCJleHAiOjE3NDk5MDQ3Mzh9.PlsqbncJZrUeeYdFS1drrpaP7zeZl2-vpHisaj_k8Ok
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImFkbWluemFkYSIsImlkIjoiNjg0ZGJkMTdmNjAzNTEwYzA5NjM5MTM4IiwiaWF0IjoxNzQ5OTM2NDk4LCJleHAiOjE3NDk5MzY2Nzh9.unHTb95zDmetogHL4k0EV3sCN5SCifqcwZNuqbZpJWA
 Content-Type: application/json
 
 {
-  "history": [1, 2, 3, 4, 5]
+  "history": 2,
+  "type": "add"
 } 
 
 ###
@@ -71,11 +72,12 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImFkb
 
 ###
 PATCH http://localhost:3333/users/me/favorite
-Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImFkbWluemFkYSIsImlkIjoiNjg0YjZlZjc0OGYyYTU3YTEyMGZlMDJiIiwiaWF0IjoxNzQ5OTA0NTU4LCJleHAiOjE3NDk5MDQ3Mzh9.PlsqbncJZrUeeYdFS1drrpaP7zeZl2-vpHisaj_k8Ok
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImFkbWluemFkYSIsImlkIjoiNjg0ZGJkMTdmNjAzNTEwYzA5NjM5MTM4IiwiaWF0IjoxNzQ5OTM0NTYzLCJleHAiOjE3NDk5MzQ3NDN9.ITkEt4eAZ5J_WjVBGmLPzQzcVOX6hVixBFwF53Ol_k8
 Content-Type: application/json
 
 {
-  "favorite": [1, 2, 3, 4, 9]
+  "favorite": 11,
+  "type": "add"
 } 
 
 ###
@@ -84,11 +86,12 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImFkb
 
 ###
 PATCH http://localhost:3333/users/me/shortcuts
-Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImFkbWluemFkYSIsImlkIjoiNjg0YjZlZjc0OGYyYTU3YTEyMGZlMDJiIiwiaWF0IjoxNzQ5OTA0NTU4LCJleHAiOjE3NDk5MDQ3Mzh9.PlsqbncJZrUeeYdFS1drrpaP7zeZl2-vpHisaj_k8Ok
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImFkbWluemFkYSIsImlkIjoiNjg0ZGJkMTdmNjAzNTEwYzA5NjM5MTM4IiwiaWF0IjoxNzQ5OTM2NzQyLCJleHAiOjE3NDk5MzY5MjJ9.wTYoQjnmGKNq7Wn2okDstP2Sx7vmhbNT4djZr2R1npE
 Content-Type: application/json
 
 {
-  "quickAccess": [1, 4, 5, 10]
+  "quickAccess": 2,
+  "type": "remove"
 }
 
 ###
@@ -143,11 +146,11 @@ Content-Type: application/json
 
 ###
 PATCH http://localhost:3333/users/me/profile
-Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImFkbWluemFkYSIsImlkIjoiNjg0YjZlZjc0OGYyYTU3YTEyMGZlMDJiIiwiaWF0IjoxNzQ5OTI1MDA4LCJleHAiOjE3NDk5MjUxODh9.RTWQvcrbM8MAwyeVwLrwyBUnpRKQOVFTG8IVaiO2hKY
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImFkbWluemFkYSIsImlkIjoiNjg0YjZlZjc0OGYyYTU3YTEyMGZlMDJiIiwiaWF0IjoxNzQ5OTI2NzYxLCJleHAiOjE3NDk5MjY5NDF9.I3-GnSWnvnS0KIK-2iRe99IOeOVdzWZGU7n5Pwo98MQ
 Content-Type: application/json
 
 {
-  "username": "adminzada",
+  "username": "admin2",
   "status": "focado",
   "avatar": "http://image"
 }

--- a/back-end/src/controllers/favorite.controller.ts
+++ b/back-end/src/controllers/favorite.controller.ts
@@ -1,6 +1,6 @@
 import {
-  getFavoritesService,
-  updateFavoriteService
+  addOrRemoveFavoriteService,
+  getFavoritesService
 } from "../services/favorite.service";
 
 export const getFavoriteController = async (request, reply) => {
@@ -20,10 +20,9 @@ export const getFavoriteController = async (request, reply) => {
 
 export const updateFavoriteController = async (request, reply) => {
   const userId = request.user?.id;
-  const { favorite } = request.body;
-
+  const { favorite, type } = request.body;
   try {
-    const updateUser = await updateFavoriteService(userId, favorite);
+    const updateUser = await addOrRemoveFavoriteService(userId, favorite, type);
     return reply.code(200).send(updateUser);
   } catch (error) {
     if (error instanceof Error && error.message === "User not found") {

--- a/back-end/src/controllers/history.controller.ts
+++ b/back-end/src/controllers/history.controller.ts
@@ -1,6 +1,6 @@
 import {
-  getHistoryService,
-  updateHistoryService
+  addOrRemoveHistoryService,
+  getHistoryService
 } from "../services/history.service";
 
 export const getHistoryController = async (request, reply) => {
@@ -20,10 +20,10 @@ export const getHistoryController = async (request, reply) => {
 
 export const updateHistoryController = async (request, reply) => {
   const id = request.user?.id;
-  const { history } = request.body;
+  const { history, type } = request.body;
 
   try {
-    const updatedUser = await updateHistoryService(id, history);
+    const updatedUser = await addOrRemoveHistoryService(id, history, type);
     return reply.code(200).send(updatedUser);
   } catch (error) {
     if (error instanceof Error && error.message === "User not found") {

--- a/back-end/src/controllers/shortcut.controller.ts
+++ b/back-end/src/controllers/shortcut.controller.ts
@@ -1,6 +1,6 @@
 import {
-  getShortcutsService,
-  updateShortcutsService
+  addOrRemoveShortcutsService,
+  getShortcutsService
 } from "../services/shortcut.service";
 
 export const getShortcutsController = async (request, reply) => {
@@ -19,10 +19,10 @@ export const getShortcutsController = async (request, reply) => {
 
 export const updateShortcutsController = async (request, reply) => {
   const id = request.user?.id;
-  const { quickAccess } = request.body;
+  const { quickAccess, type } = request.body;
 
   try {
-    const newUser = await updateShortcutsService(id, quickAccess);
+    const newUser = await addOrRemoveShortcutsService(id, quickAccess, type);
     return reply.code(200).send(newUser);
   } catch (error) {
     if (error instanceof Error && error.message === "User not found") {

--- a/back-end/src/dto/favorite/updateFavorite.dto.ts
+++ b/back-end/src/dto/favorite/updateFavorite.dto.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
 
-export const updateFavoriteDto = z.array(z.number());
+export const updateFavoriteDto = z.number();
 
 export type UpdateFavoriteDto = z.infer<typeof updateFavoriteDto>;

--- a/back-end/src/dto/generalSettings/UpdateGeneralSettings.dto.ts
+++ b/back-end/src/dto/generalSettings/UpdateGeneralSettings.dto.ts
@@ -1,9 +1,9 @@
 import { z } from "zod";
 
 export const updateGeneralSettingsDto = z.object({
-  backgroundImage: z.string(),
-  outputMethod: z.string(),
-  themeColor: z.string()
+  backgroundImage: z.string().optional(),
+  outputMethod: z.string().optional(),
+  themeColor: z.string().optional()
 });
 
 export type UpdateGeneralSettingsDto = z.infer<typeof updateGeneralSettingsDto>;

--- a/back-end/src/dto/history/updateHistory.dto.ts
+++ b/back-end/src/dto/history/updateHistory.dto.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
 
-export const updateHistoryDto = z.array(z.number());
+export const updateHistoryDto = z.number();
 
 export type UpdateHistoryDto = z.infer<typeof updateHistoryDto>;

--- a/back-end/src/dto/shortcuts/updateShortcuts.dto.ts
+++ b/back-end/src/dto/shortcuts/updateShortcuts.dto.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
 
-export const updateShortcutsDto = z.array(z.number());
+export const updateShortcutsDto = z.number();
 
 export type UpdateShortcutsDto = z.infer<typeof updateShortcutsDto>;

--- a/back-end/src/repository/user.repository.ts
+++ b/back-end/src/repository/user.repository.ts
@@ -24,3 +24,19 @@ export const updateUser = async (id: string, user: any) => {
     { new: true }
   );
 };
+
+export const updateUserArrays = async (id: string, user: any) => {
+  return await UserSchema.findByIdAndUpdate(
+    { _id: id },
+    { $addToSet: user },
+    { new: true }
+  );
+};
+
+export const removeUserArrays = async (id: string, user: any) => {
+  return await UserSchema.findByIdAndUpdate(
+    { _id: id },
+    { $pull: user },
+    { new: true }
+  );
+};

--- a/back-end/src/routes/favorite.route.ts
+++ b/back-end/src/routes/favorite.route.ts
@@ -41,7 +41,8 @@ export function favoriteRoute(app) {
         description: "",
         tags: [""],
         body: z.object({
-          favorite: updateFavoriteDto
+          favorite: updateFavoriteDto,
+          type: z.string()
         }),
         response: {
           200: userSchema,

--- a/back-end/src/routes/hisory.route.ts
+++ b/back-end/src/routes/hisory.route.ts
@@ -42,7 +42,8 @@ export function historyRoute(app) {
           "Updates the `history` field of the currently authenticated user. The request body must contain an array of numbers representing the new history.",
         tags: ["User", "History"],
         body: z.object({
-          history: updateHistoryDto
+          history: updateHistoryDto,
+          type: z.string()
         }),
         response: {
           200: userSchema,

--- a/back-end/src/routes/shortcut.route.ts
+++ b/back-end/src/routes/shortcut.route.ts
@@ -41,7 +41,8 @@ export function shortcutRoute(app) {
         description: "",
         tags: [""],
         body: z.object({
-          quickAccess: updateShortcutsDto
+          quickAccess: updateShortcutsDto,
+          type: z.string()
         }),
         response: {
           200: userSchema,

--- a/back-end/src/services/favorite.service.ts
+++ b/back-end/src/services/favorite.service.ts
@@ -1,6 +1,11 @@
 import { config } from "dotenv";
 import { UpdateFavoriteDto } from "../dto/favorite/updateFavorite.dto";
-import { getUserById, updateUser } from "../repository/user.repository";
+import {
+  getUserById,
+  removeUserArrays,
+  updateUser,
+  updateUserArrays
+} from "../repository/user.repository";
 
 export const getFavoritesService = async (id: string) => {
   const user = await getUserById(id);
@@ -9,14 +14,21 @@ export const getFavoritesService = async (id: string) => {
   return user.config.favorite;
 };
 
-export const updateFavoriteService = async (
+export const addOrRemoveFavoriteService = async (
   id: string,
-  favorite: UpdateFavoriteDto
+  favorite: UpdateFavoriteDto,
+  type: string
 ) => {
   const user = await getUserById(id);
   if (!user) throw new Error("User not found");
 
-  return await updateUser(id, {
+  if (type === "add") {
+    return await updateUserArrays(id, {
+      "config.favorite": favorite
+    });
+  }
+
+  return await removeUserArrays(id, {
     "config.favorite": favorite
   });
 };

--- a/back-end/src/services/folder.service.ts
+++ b/back-end/src/services/folder.service.ts
@@ -13,6 +13,7 @@ export const updateFoldersService = async (
 ) => {
   const user = await getUserById(id);
   if (!user) throw new Error("User not found");
+
   return await updateUser(id, {
     "config.folders": folders
   });

--- a/back-end/src/services/history.service.ts
+++ b/back-end/src/services/history.service.ts
@@ -1,4 +1,9 @@
-import { getUserById, updateUser } from "../repository/user.repository";
+import {
+  getUserById,
+  removeUserArrays,
+  updateUser,
+  updateUserArrays
+} from "../repository/user.repository";
 import { UpdateHistoryDto } from "../dto/history/updateHistory.dto";
 
 export const getHistoryService = async (id: string) => {
@@ -7,12 +12,17 @@ export const getHistoryService = async (id: string) => {
   return user.history;
 };
 
-export const updateHistoryService = async (
+export const addOrRemoveHistoryService = async (
   id: string,
-  updateHistory: UpdateHistoryDto
+  updateHistory: UpdateHistoryDto,
+  type: string
 ) => {
   const user = await getUserById(id);
   if (!user) throw new Error("User not found");
 
-  return await updateUser(id, { history: updateHistory });
+  if (type === "add") {
+    return await updateUserArrays(id, { history: updateHistory });
+  }
+
+  return await removeUserArrays(id, { history: updateHistory });
 };

--- a/back-end/src/services/shortcut.service.ts
+++ b/back-end/src/services/shortcut.service.ts
@@ -1,5 +1,10 @@
 import { UpdateShortcutsDto } from "../dto/shortcuts/updateShortcuts.dto";
-import { getUserById, updateUser } from "../repository/user.repository";
+import {
+  getUserById,
+  removeUserArrays,
+  updateUser,
+  updateUserArrays
+} from "../repository/user.repository";
 
 export const getShortcutsService = async (id: string) => {
   const user = await getUserById(id);
@@ -7,14 +12,21 @@ export const getShortcutsService = async (id: string) => {
   return user.config.quickAccess;
 };
 
-export const updateShortcutsService = async (
+export const addOrRemoveShortcutsService = async (
   id: string,
-  shortcuts: UpdateShortcutsDto
+  shortcuts: UpdateShortcutsDto,
+  type: string
 ) => {
   const user = await getUserById(id);
   if (!user) throw new Error("User not found");
 
-  return await updateUser(id, {
+  if (type === "add") {
+    return await updateUserArrays(id, {
+      "config.quickAccess": shortcuts
+    });
+  }
+
+  return await removeUserArrays(id, {
     "config.quickAccess": shortcuts
   });
 };


### PR DESCRIPTION
What I did:

Refactored the user repository by creating three dedicated functions for user updates:

updateUser (for general field updates using $set)

updateUserArrays (for array additions using $addToSet)

removeUserArrays (for array removals using $pull)

Added a new type field in the update process to differentiate between "add" and "remove" operations when updating user arrays like history, shortcuts, and favorites.

Why I did it:
The previous implementation overwrote entire arrays when updating, which could cause data loss.
This refactor improves control and allows incremental updates (additions and removals) without overwriting existing array data.

How to test it:

Test adding items to history, shortcuts, and favorites with type: "add".

Test removing items with type: "remove".

Verify that non-targeted data remains untouched.