### PR TITLE
feat: add get folder by folderName endpoint and refactor folder updat…

### DIFF
--- a/back-end/api.http
+++ b/back-end/api.http
@@ -25,13 +25,13 @@ POST http://localhost:3333/login
 Content-Type: application/json
 
 {
-  "username": "adminzada",
+  "username": "admin34",
   "password": "0000"
 }
 
 ###
 GET http://localhost:3333/user/me
-Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImFkbWluemFkYSIsImlkIjoiNjg0YjZlZjc0OGYyYTU3YTEyMGZlMDJiIiwiaWF0IjoxNzQ5OTA0MDk1LCJleHAiOjE3NDk5MDQyNzV9._1xBUbBVy-HfbGfIfkIBc0rp9aP8mNoBUMkJ7pGUwqs
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImFkbWluMzQiLCJpZCI6IjY4NGI2ZWY3NDhmMmE1N2ExMjBmZTAyYiIsImlhdCI6MTc0OTk4OTg3MCwiZXhwIjoxNzQ5OTkwMDUwfQ.ayp1W6YVzZAKoCBc1wq8W3uTh6mXjQWT31WYvL3k6XQ
 
 ###
 GET http://localhost:3333/user/search/admin2
@@ -71,7 +71,7 @@ GET http://localhost:3333/users/me/favorites
 Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImFkbWluMiIsImlkIjoiNjgzODY4YWJlNDRkM2UzNjk1M2U4NmJkIiwiaWF0IjoxNzQ5NDc1MjMxLCJleHAiOjE3NDk0NzU0MTF9.S3Fqw28mzboU8PvAe9OAJ0U32rlkVKJvtCJXVlcWc8Y
 
 ###
-PATCH http://localhost:3333/users/me/favorite
+PATCH http://localhost:3333/users/me/favorites
 Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImFkbWluemFkYSIsImlkIjoiNjg0ZGJkMTdmNjAzNTEwYzA5NjM5MTM4IiwiaWF0IjoxNzQ5OTM0NTYzLCJleHAiOjE3NDk5MzQ3NDN9.ITkEt4eAZ5J_WjVBGmLPzQzcVOX6hVixBFwF53Ol_k8
 Content-Type: application/json
 
@@ -96,24 +96,23 @@ Content-Type: application/json
 
 ###
 GET http://localhost:3333/users/me/folders
-Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImFkbWluMiIsImlkIjoiNjgzODY4YWJlNDRkM2UzNjk1M2U4NmJkIiwiaWF0IjoxNzQ5NDc2NDM5LCJleHAiOjE3NDk0NzY2MTl9.3361RRJEJqcq6tKxm2oD4-8FNzMToDThIAgbrsLl7E8
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImFkbWluMzQiLCJpZCI6IjY4NGI2ZWY3NDhmMmE1N2ExMjBmZTAyYiIsImlhdCI6MTc0OTk5MDE5MiwiZXhwIjoxNzQ5OTkwMzcyfQ.DuhY08ECGmmABt67Uzcypa39boUoRoZ0B1iv-9kF5Nk
+
+###
+GET http://localhost:3333/users/me/folders/lidos
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImFkbWluMzQiLCJpZCI6IjY4NGI2ZWY3NDhmMmE1N2ExMjBmZTAyYiIsImlhdCI6MTc0OTk5MTA3MiwiZXhwIjoxNzQ5OTkxMjUyfQ.fYpmYbM-FSQzflOhNPSu05th7reUX-BZl5NNmpCteq0
 
 ###
 PATCH http://localhost:3333/users/me/folders
-Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImFkbWluemFkYSIsImlkIjoiNjg0YjZlZjc0OGYyYTU3YTEyMGZlMDJiIiwiaWF0IjoxNzQ5OTA5MTI3LCJleHAiOjE3NDk5MDkzMDd9.jWL66YP9lntvyVp9wy2G5VrnTnQfutDhH81Oz7JTmbQ
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImFkbWluMzQiLCJpZCI6IjY4NGI2ZWY3NDhmMmE1N2ExMjBmZTAyYiIsImlhdCI6MTc0OTk5MTM3MywiZXhwIjoxNzQ5OTkxNTUzfQ.yLBCMiDn8krkC1auaSddhUb6y-cBCB-SxKq3XsWHDcc
 Content-Type: application/json
 
 {
-  "folders": [
-  {
-    "folderName": "favoritos",
-    "wikipages": [1, 2, 3]
-  },
-  {
-    "folderName": "lidos",
-    "wikipages": [1, 10, 61]
+  "type": "remove",
+  "folders": {
+    "folderName": "teste2",
+  "wikipages": [1, 2, 3, 5]
   }
-  ]
 }
 
 ###

--- a/back-end/src/controllers/folder.controller.ts
+++ b/back-end/src/controllers/folder.controller.ts
@@ -1,6 +1,7 @@
 import {
-  getFoldersService,
-  updateFoldersService
+  addOrRemoveFoldersService,
+  getFolderByFolderNameService,
+  getFoldersService
 } from "../services/folder.service";
 
 export const getFoldersController = async (request, reply) => {
@@ -18,12 +19,30 @@ export const getFoldersController = async (request, reply) => {
   }
 };
 
+export const getFolderByFolderNameController = async (request, reply) => {
+  const id = request.user?.id;
+  const { folderName } = request.params;
+  try {
+    const folder = await getFolderByFolderNameService(id, folderName);
+    return reply.code(200).send(folder);
+  } catch (error) {
+    if (error instanceof Error && error.message === "User not found") {
+      return reply.code(404).send({ message: "User not found" });
+    }
+    if (error instanceof Error && error.message === "Folder not found") {
+      return reply.code(404).send({ message: "Folder not found" });
+    }
+    console.error(error);
+    return reply.code(500).send({ message: "User not found" });
+  }
+};
+
 export const updateFoldersController = async (request, reply) => {
   const id = request.user?.id;
-  const { folders } = request.body;
+  const { folders, type } = request.body;
 
   try {
-    const newUser = await updateFoldersService(id, folders);
+    const newUser = await addOrRemoveFoldersService(id, folders, type);
     return reply.code(200).send(newUser);
   } catch (error) {
     if (error instanceof Error && error.message === "User not found") {

--- a/back-end/src/repository/user.repository.ts
+++ b/back-end/src/repository/user.repository.ts
@@ -40,3 +40,15 @@ export const removeUserArrays = async (id: string, user: any) => {
     { new: true }
   );
 };
+
+export const getUserFolder = async (id: string, folderName: string) => {
+  return await UserSchema.findOne(
+    {
+      _id: id,
+      "config.folders.folderName": folderName
+    },
+    {
+      "config.folders.$": 1
+    }
+  );
+};

--- a/back-end/src/routes/favorite.route.ts
+++ b/back-end/src/routes/favorite.route.ts
@@ -33,7 +33,7 @@ export function favoriteRoute(app) {
   );
 
   app.patch(
-    "/users/me/favorite",
+    "/users/me/favorites",
     {
       preHandler: authenticateToken,
       schema: {

--- a/back-end/src/routes/folder.route.ts
+++ b/back-end/src/routes/folder.route.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import {
+  getFolderByFolderNameController,
   getFoldersController,
   updateFoldersController
 } from "../controllers/folder.controller";
@@ -21,7 +22,7 @@ export function folderRoute(app) {
           200: z.array(
             z.object({
               folderName: z.string(),
-              list: z.array(z.number())
+              wikipages: z.array(z.number())
             })
           ),
           404: z.object({
@@ -37,6 +38,35 @@ export function folderRoute(app) {
     getFoldersController
   );
 
+  app.get(
+    "/users/me/folders/:folderName",
+    {
+      preHandler: authenticateToken,
+      schema: {
+        summary: "",
+        description: "",
+        tags: [""],
+        params: z.object({
+          folderName: z.string()
+        }),
+        response: {
+          200: z.object({
+            folderName: z.string(),
+            wikipages: z.array(z.number())
+          }),
+          404: z.object({
+            message: z.string()
+          }),
+          500: z.object({
+            message: z.string(),
+            error: z.string()
+          })
+        }
+      }
+    },
+    getFolderByFolderNameController
+  );
+
   app.patch(
     "/users/me/folders",
     {
@@ -46,7 +76,8 @@ export function folderRoute(app) {
         description: "",
         tags: [""],
         body: z.object({
-          folders: z.array(updateFoldersDto)
+          folders: updateFoldersDto,
+          type: z.string()
         }),
         response: {
           200: userSchema,

--- a/back-end/src/services/folder.service.ts
+++ b/back-end/src/services/folder.service.ts
@@ -1,5 +1,11 @@
 import { UpdateFoldersDto } from "../dto/folders/updateFolders.dto";
-import { getUserById, updateUser } from "../repository/user.repository";
+import {
+  getUserById,
+  getUserFolder,
+  removeUserArrays,
+  updateUser,
+  updateUserArrays
+} from "../repository/user.repository";
 
 export const getFoldersService = async (id: string) => {
   const user = await getUserById(id);
@@ -7,14 +13,33 @@ export const getFoldersService = async (id: string) => {
   return user.config.folders;
 };
 
-export const updateFoldersService = async (
+export const getFolderByFolderNameService = async (
   id: string,
-  folders: UpdateFoldersDto
+  folderName: string
 ) => {
   const user = await getUserById(id);
   if (!user) throw new Error("User not found");
 
-  return await updateUser(id, {
+  const folders = await getUserFolder(id, folderName);
+  if (!folders) throw new Error("Folder not found");
+  return folders.config.folders[0];
+};
+
+export const addOrRemoveFoldersService = async (
+  id: string,
+  folders: UpdateFoldersDto,
+  type: string
+) => {
+  const user = await getUserById(id);
+  if (!user) throw new Error("User not found");
+
+  if (type === "add") {
+    return await updateUserArrays(id, {
+      "config.folders": folders
+    });
+  }
+
+  return await removeUserArrays(id, {
     "config.folders": folders
   });
 };


### PR DESCRIPTION
What I did:

Created a new endpoint to retrieve a specific folder by its folderName.
→ This includes new controller, service method, and route.

Refactored the folder update logic:
→ Previously, updating folders required sending the entire folders array, which caused overwrites.
→ Now, the endpoint accepts a single folder object and a type parameter ("add" or "remove") to control if the folder should be added or removed.

Why I did it:

To allow users to query individual folders easily.

To prevent accidental overwrites of the entire folders list when making folder updates.

To provide a more scalable and flexible API for folder management.

How to test it:

For Get Folder by Name:

Send a GET request with a folder name and check that the correct folder object is returned.

For Folder Update:

Test adding a new folder by sending a request with type: "add" and the folder data.

Test removing a folder by sending type: "remove" and the target folder.

Verify that other folders remain untouched in both cases.