### PR TITLE
feat: add endpoint to add or remove wikipages from a specific user fo…

### DIFF
--- a/back-end/api.http
+++ b/back-end/api.http
@@ -116,6 +116,18 @@ Content-Type: application/json
 }
 
 ###
+PATCH http://localhost:3333/users/me/folders/teste/items
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImFkbWluMzQiLCJpZCI6IjY4NGI2ZWY3NDhmMmE1N2ExMjBmZTAyYiIsImlhdCI6MTc1MDAxMTU4MCwiZXhwIjoxNzUwMDExNzYwfQ.l3B_Om2y2HzBfRcTibkJkNGe-Oh94iMuFKJF0sfYGLA
+Content-Type: application/json
+
+{
+  "type": "remove",
+  "item": 2
+}
+
+
+###
+
 GET http://localhost:3333/users/me/general-settings
 Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImFkbWluMiIsImlkIjoiNjgzODY4YWJlNDRkM2UzNjk1M2U4NmJkIiwiaWF0IjoxNzQ5NDc4MTQ3LCJleHAiOjE3NDk0NzgzMjd9.reqi-kPIanNruZaiSCYFo3Zt497sqHgFtR_X7gzPMS0
 

--- a/back-end/src/controllers/folder.controller.ts
+++ b/back-end/src/controllers/folder.controller.ts
@@ -1,5 +1,6 @@
 import {
   addOrRemoveFoldersService,
+  addOrRemoveItemInFolderService,
   getFolderByFolderNameService,
   getFoldersService
 } from "../services/folder.service";
@@ -47,6 +48,31 @@ export const updateFoldersController = async (request, reply) => {
   } catch (error) {
     if (error instanceof Error && error.message === "User not found") {
       return reply.code(404).send({ message: "User not found" });
+    }
+    console.error(error);
+    return reply.code(500).send({ message: "User not found" });
+  }
+};
+
+export const addOrRemoveItemInFolderController = async (request, reply) => {
+  const id = request.user?.id;
+  const { folderName } = request.params;
+  const { type, item } = request.body;
+
+  try {
+    const newUser = await addOrRemoveItemInFolderService(
+      id,
+      folderName,
+      type,
+      item
+    );
+    return reply.code(200).send(newUser);
+  } catch (error) {
+    if (error instanceof Error && error.message === "User not found") {
+      return reply.code(404).send({ message: "User not found" });
+    }
+    if (error instanceof Error && error.message === "Folder not found") {
+      return reply.code(404).send({ message: "Folder not found" });
     }
     console.error(error);
     return reply.code(500).send({ message: "User not found" });

--- a/back-end/src/repository/user.repository.ts
+++ b/back-end/src/repository/user.repository.ts
@@ -52,3 +52,37 @@ export const getUserFolder = async (id: string, folderName: string) => {
     }
   );
 };
+
+export const addItemToFolder = async (
+  id: string,
+  folderName: string,
+  item: number
+) => {
+  return await UserSchema.findOneAndUpdate(
+    { _id: id },
+    {
+      $addToSet: { "config.folders.$[folder].wikipages": item }
+    },
+    {
+      arrayFilters: [{ "folder.folderName": folderName }],
+      new: true
+    }
+  );
+};
+
+export const removeItemFromFolder = async (
+  id: string,
+  folderName: string,
+  item: number
+) => {
+  return await UserSchema.findOneAndUpdate(
+    { _id: id },
+    {
+      $pull: { "config.folders.$[folder].wikipages": item }
+    },
+    {
+      arrayFilters: [{ "folder.folderName": folderName }],
+      new: true
+    }
+  );
+};

--- a/back-end/src/routes/folder.route.ts
+++ b/back-end/src/routes/folder.route.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import {
+  addOrRemoveItemInFolderController,
   getFolderByFolderNameController,
   getFoldersController,
   updateFoldersController
@@ -92,5 +93,35 @@ export function folderRoute(app) {
       }
     },
     updateFoldersController
+  );
+
+  app.patch(
+    "/users/me/folders/:folderName/items",
+    {
+      preHandler: authenticateToken,
+      schema: {
+        summary: "",
+        description: "",
+        tags: [""],
+        params: z.object({
+          folderName: z.string()
+        }),
+        body: z.object({
+          type: z.string(),
+          item: z.number()
+        }),
+        response: {
+          200: userSchema,
+          404: z.object({
+            message: z.string()
+          }),
+          500: z.object({
+            message: z.string(),
+            error: z.string()
+          })
+        }
+      }
+    },
+    addOrRemoveItemInFolderController
   );
 }

--- a/back-end/src/services/folder.service.ts
+++ b/back-end/src/services/folder.service.ts
@@ -1,7 +1,9 @@
 import { UpdateFoldersDto } from "../dto/folders/updateFolders.dto";
 import {
+  addItemToFolder,
   getUserById,
   getUserFolder,
+  removeItemFromFolder,
   removeUserArrays,
   updateUser,
   updateUserArrays
@@ -42,4 +44,19 @@ export const addOrRemoveFoldersService = async (
   return await removeUserArrays(id, {
     "config.folders": folders
   });
+};
+
+export const addOrRemoveItemInFolderService = async (
+  id: string,
+  folderName: string,
+  type: string,
+  item: number
+) => {
+  await getFolderByFolderNameService(id, folderName);
+
+  if (type === "add") {
+    return await addItemToFolder(id, folderName, item);
+  }
+
+  return await removeItemFromFolder(id, folderName, item);
 };


### PR DESCRIPTION
What I did:
Implemented a new endpoint that allows adding or removing a wikipage ID from the wikipages array inside a specific user folder.
This includes changes in:

Controller

Service

Routes

DTO for input validation

The API accepts a folder name and a type parameter ("add" or "remove") to define the action.

Why I did it:
To give users more granular control over the contents of each folder, allowing them to manage individual wikipages without needing to update the entire folder object.