### PR TITLE
feat: add user existence check by email or username before user creation

### DIFF
--- a/back-end/src/repository/user.repository.ts
+++ b/back-end/src/repository/user.repository.ts
@@ -9,6 +9,10 @@ export const getUserByUsername = async (username: string) => {
   return await UserSchema.findOne({ username: username });
 };
 
+export const getUserByEmail = async (email: string) => {
+  return await UserSchema.findOne({ email: email });
+};
+
 export const createUser = async (user: any) => {
   return await UserSchema.create(user);
 };

--- a/back-end/src/services/user.service.ts
+++ b/back-end/src/services/user.service.ts
@@ -3,6 +3,7 @@ import { CreateUserDto } from "../dto/user/createUser.dto";
 import {
   createUser,
   deleteUser,
+  getUserByEmail,
   getUserById,
   getUserByUsername,
   updateUser
@@ -21,9 +22,16 @@ export const getUserByUsernameService = async (username: string) => {
   return user;
 };
 
-export const createUserService = async (user: CreateUserDto) => {
-  const existUser = await getUserByUsername(user.username);
+const verifyUserExists = async (username: string, email: string) => {
+  let existUser = await getUserByUsername(username);
   if (existUser) throw new Error("User already exists");
+  existUser = await getUserByEmail(email);
+  if (existUser) throw new Error("User already exists");
+  return existUser;
+};
+
+export const createUserService = async (user: CreateUserDto) => {
+  await verifyUserExists(user.username, user.email);
 
   const newUser = {
     username: user.username,


### PR DESCRIPTION
What I did:

Created a new repository function to get a user by email (getUserByEmail).

Added a service function to check if a user already exists by username or email.

Integrated this check into the existing user creation logic, preventing duplicate users from being created.

Why I did it:
Previously, the system allowed creating multiple users with the same email or username, which could lead to conflicts.
This update enforces uniqueness for these fields at the service layer.

How to test it:

Try creating a user with an existing email or username → It should throw an error.

Try creating a user with unique values → It should succeed.