### PR TITLE
feat: replace match query with query_string to support advanced searc…

### DIFF
--- a/back-end/src/services/elasticsearch.service.ts
+++ b/back-end/src/services/elasticsearch.service.ts
@@ -1,4 +1,5 @@
 import { Client, errors } from "@elastic/elasticsearch";
+import { buildElasticQuery } from "../utils/generateQuery";
 
 type WikipediaDocument = {
   title: string;
@@ -25,36 +26,7 @@ export const getDocsWikipediaService = async (
   page: number,
   pageSize: number
 ) => {
-  const isExactPhrase = query.match(/^".+"$/);
-
-  const elasticQuery = isExactPhrase
-    ? {
-        bool: {
-          should: [
-            {
-              match_phrase: {
-                content: {
-                  query: query.replace(/"/g, ""),
-                  boost: 2
-                }
-              }
-            },
-            {
-              match: {
-                content: {
-                  query,
-                  boost: 1
-                }
-              }
-            }
-          ]
-        }
-      }
-    : {
-        match: {
-          content: query
-        }
-      };
+  const elasticQuery = buildElasticQuery(query);
 
   const results = await elasticClient.search<WikipediaDocument>({
     index: "wikipedia",

--- a/back-end/src/utils/generateQuery.ts
+++ b/back-end/src/utils/generateQuery.ts
@@ -1,0 +1,12 @@
+export function buildElasticQuery(userQuery) {
+  return {
+    query_string: {
+      query: userQuery,
+      default_field: "content",
+      phrase_slop: 2,
+      boost: 1.0,
+      analyze_wildcard: true,
+      allow_leading_wildcard: false
+    }
+  };
+}


### PR DESCRIPTION
What I did:

Replaced the Elasticsearch search logic from a simple match query to a query_string query.

This enables support for advanced search operators, including:

Boosting: e.g., notebook^3

Exact phrase search: e.g., "fast SSD"

Exclusion: e.g., -intel

Logical operators: OR, AND

Wildcards: e.g., noteb*

Logical grouping: e.g., (gamer OR workstation) AND asus

Why I did it:
To provide more powerful and flexible search options for users, allowing complex queries and refined search control directly via the API.

How to test it:

Perform different search queries using the operators listed above and verify that Elasticsearch returns correct and expected results.

Test both simple and complex query examples to ensure backward compatibility and new feature support.