### PR TITLE
feat: add semantic search endpoint for Wikipedia index using KNN and …

### DIFF
--- a/back-end/api.http
+++ b/back-end/api.http
@@ -11,12 +11,20 @@ GET http://localhost:3333/wikipedia/mostViews/9
 PATCH http://localhost:3333/wikipedia/increment/332
 
 ###
+POST http://localhost:3333/wikipedia/semantic_search
+Content-Type: application/json
+
+{
+  "query": "Quero documentos que falem sobre machine learning"
+}
+
+###
 POST http://localhost:3333/signup
 Content-Type: application/json
 
 {
-  "username": "adminzada",
-  "email": "meu@emailzada.com",
+  "username": "adminzada222",
+  "email": "meu2@emailzada.com",
   "password": "0000"
 }
 

--- a/back-end/src/controllers/semanticSearch.controller.ts
+++ b/back-end/src/controllers/semanticSearch.controller.ts
@@ -1,0 +1,13 @@
+import { getDocsSemanticWikipediaService } from "../services/semanticSearch.service";
+
+export const semanticSearchController = async (request, reply) => {
+  const { query } = request.body;
+
+  try {
+    const response = await getDocsSemanticWikipediaService(query);
+    return reply.code(200).send(response);
+  } catch (error) {
+    console.error(error);
+    return reply.code(500).send({ message: "Internal server error" });
+  }
+};

--- a/back-end/src/routes/semanticSearch.route.ts
+++ b/back-end/src/routes/semanticSearch.route.ts
@@ -1,0 +1,32 @@
+import { z } from "zod";
+import { semanticSearchController } from "../controllers/semanticSearch.controller";
+import { resultSchema } from "../schemas/elasticsearch.schema";
+
+export function semanticSearch(app) {
+  app.post(
+    "/wikipedia/semantic_search",
+    {
+      schema: {
+        summary: "",
+        description: "",
+        tags: [""],
+        body: z.object({
+          query: z.string()
+        }),
+        response: {
+          200: z.object({
+            total: z.number(),
+            results: z
+              .array(resultSchema)
+              .describe("List of documents matching the search query")
+          }),
+          500: z.object({
+            message: z.string(),
+            error: z.string()
+          })
+        }
+      }
+    },
+    semanticSearchController
+  );
+}

--- a/back-end/src/server.ts
+++ b/back-end/src/server.ts
@@ -19,6 +19,7 @@ import { shortcutRoute } from "./routes/shortcut.route";
 import { folderRoute } from "./routes/folder.route";
 import { generalSettingsRoute } from "./routes/generalSettings.route";
 import { cardSettingsRoute } from "./routes/cardSettings.route";
+import { semanticSearch } from "./routes/semanticSearch.route";
 
 // criando conexao com mongo
 
@@ -36,6 +37,7 @@ app.register(shortcutRoute);
 app.register(folderRoute);
 app.register(generalSettingsRoute);
 app.register(cardSettingsRoute);
+app.register(semanticSearch)
 
 app.setValidatorCompiler(validatorCompiler);
 app.setSerializerCompiler(serializerCompiler);

--- a/back-end/src/services/semanticSearch.service.ts
+++ b/back-end/src/services/semanticSearch.service.ts
@@ -1,0 +1,50 @@
+import { Client } from "@elastic/elasticsearch";
+import { generateEmbeding } from "../utils/generateEmbed";
+
+type WikipediaDocument = {
+  title: string;
+  url: string;
+  content: string;
+  dt_creation: string;
+  reading_time: number;
+};
+
+export const elasticClient = new Client({
+  node: "https://localhost:9200",
+  auth: {
+    username: "elastic",
+    password: "user123"
+  },
+  tls: {
+    rejectUnauthorized: false
+  }
+});
+
+export const getDocsSemanticWikipediaService = async (query: string) => {
+  const queryEmbedding = await generateEmbeding(query);
+
+  const semanticSearchQuery = {
+    knn: {
+      field: "embedding", // Campo onde os embeddings estão armazenados
+      query_vector: queryEmbedding,
+      k: 3, // Número de resultados
+      num_candidates: 100 // Número de candidatos a considerar
+    }
+  };
+
+  const results = await elasticClient.search<WikipediaDocument>({
+    index: "wikipedia_semantic",
+    body: semanticSearchQuery
+  });
+
+  return {
+    total:
+      typeof results.hits.total === "number"
+        ? results.hits.total
+        : results.hits.total?.value || 0,
+    results: results.hits.hits.map(item => ({
+      _id: item._id,
+      ...item._source
+    }))
+  };
+};

--- a/back-end/src/utils/generateEmbed.ts
+++ b/back-end/src/utils/generateEmbed.ts
@@ -1,0 +1,22 @@
+export const generateEmbeding = async (query: string) => {
+  try {
+    const response = await fetch("http://localhost:8000/embed", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        text: query
+      })
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+    const data = await response.json();
+    return data.embedding; // Retorna o array de embeddings
+  } catch (error) {
+    console.error("Error generating embedding:", error);
+    throw error;
+  }
+};


### PR DESCRIPTION
What I did:

- Created a new API endpoint for semantic search on the wikipedia_semantic index in Elasticsearch.

The flow:

- The user sends a query string.

- The API sends this query to the external Python microservice to generate its embedding (using all-MiniLM-L6-v2).

- After receiving the embedding, the API performs a KNN search on Elasticsearch targeting the embedding field.

- Returns the top 3 closest results based on semantic similarity.

Why I did it:
To enable semantic search capabilities over the Wikipedia dataset, improving relevance and contextual matching for user queries.

How to test it:

- Start the embedding microservice and the API.

- Send a request like:

```json
  {
    "query": "What is machine learning?"
  }
```