### PR TITLE
feat: integrate chat input with semantic search API endpoint

### DIFF
--- a/front-end/src/api-client/elastic.ts
+++ b/front-end/src/api-client/elastic.ts
@@ -1,24 +1,24 @@
-import { API } from './api'
+import { API } from "./api";
 
 export type Result = {
-  _id: number
-  title: string
-  url: string
-  content: string
-  reading_time: number
-  access_count: number
-  dt_creation: string
-}
+  _id: number;
+  title: string;
+  url: string;
+  content: string;
+  reading_time: number;
+  access_count: number;
+  dt_creation: string;
+};
 
 export type Results = {
-  total: number
-  results: Result[]
-}
+  total: number;
+  results: Result[];
+};
 
 export const getMostViewedDocs = async (limit: number): Promise<Result[]> => {
-  const response = await API.get(`/wikipedia/mostViews/${limit}`)
-  return response.data
-}
+  const response = await API.get(`/wikipedia/mostViews/${limit}`);
+  return response.data;
+};
 
 export const searchDocs = async (
   query: string,
@@ -27,10 +27,15 @@ export const searchDocs = async (
 ): Promise<Results> => {
   const response = await API.get(
     `/wikipedia/search?query=${query}&page=${page}&pageSize=${pageSize}`
-  )
-  return response.data
-}
+  );
+  return response.data;
+};
+
+export const semanticSearch = async (query: string): Promise<Results> => {
+  const response = await API.post("/wikipedia/semantic_search", { query });
+  return response.data;
+};
 
 export const addNumViewDoc = async (id: string) => {
-  await API.get(`/wikipedia/increment/${id}`)
-}
+  await API.get(`/wikipedia/increment/${id}`);
+};

--- a/front-end/src/components/ChatBubble.tsx
+++ b/front-end/src/components/ChatBubble.tsx
@@ -2,13 +2,15 @@ import { UserCircle2, LinkIcon } from "lucide-react";
 
 import chatIcon from "../assets/chat-bot-icon.png";
 import { SearchDocument } from "./SearchDocument";
+import type { Result } from "../api-client/elastic";
 
 type ChatBubbleProps = {
   type: "response" | "query" | "load";
   text?: string;
+  results?: Result[];
 };
 
-export const ChatBubble = ({ type, text }: ChatBubbleProps) => {
+export const ChatBubble = ({ type, text, results }: ChatBubbleProps) => {
   return (
     <>
       {type === "query" ? (
@@ -21,21 +23,17 @@ export const ChatBubble = ({ type, text }: ChatBubbleProps) => {
           <img src={chatIcon} alt="" />
 
           <div className="chat-bubble">
-            Aqui estão alguns resultados:
-            <div className="bot-results">
-              <span>
-                <LinkIcon size={10} />
-                Como Posso melhorar o desempenho do meu Notebook?
-              </span>
-              <span>
-                <LinkIcon size={10} />
-                Como Posso melhorar o desempenho do meu Notebook?
-              </span>
-              <span>
-                <LinkIcon size={10} />
-                Como Posso melhorar o desempenho do meu Notebook?
-              </span>
-            </div>
+            {text}
+            {results && results.length > 0 && (
+              <div className="bot-results">
+                {results.map((item, index) => (
+                  <span key={index}>
+                    <LinkIcon size={10} />
+                    {item.title}
+                  </span>
+                ))}
+              </div>
+            )}
           </div>
         </div>
       ) : (

--- a/front-end/src/components/PanelChatBot.tsx
+++ b/front-end/src/components/PanelChatBot.tsx
@@ -1,7 +1,8 @@
 import { SendHorizonal, MessageCircleMore } from "lucide-react";
-
 import { ChatBubble } from "./ChatBubble";
 import { useState } from "react";
+import { semanticSearch } from "../api-client/elastic";
+import type { Result } from "../api-client/elastic";
 
 type Message = {
   text: string;
@@ -11,19 +12,34 @@ type Message = {
 export const PanelChatBot = () => {
   const [messages, setMessages] = useState<Message[]>([]);
   const [inputValue, setInputValue] = useState("");
+  const [documents, setDocuments] = useState<Result[]>([]);
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!inputValue.trim()) return;
 
     // Adiciona a nova mensagem do usuário
     setMessages(prev => [...prev, { text: inputValue, type: "query" }]);
-    setMessages(prev => [...prev, { text: "", type: "response" }]);
-    // Limpa o input
-    setInputValue("");
 
-    // Aqui você poderia adicionar lógica para obter a resposta do chatbot
-    // e então adicionar uma mensagem do tipo 'response'
+    try {
+      const response = await semanticSearch(inputValue);
+
+      setDocuments(prev => [...prev, ...response.results]);
+
+      setMessages(prev => [
+        ...prev,
+        {
+          text: "Aqui estão alguns resultados:",
+          type: "response"
+        }
+      ]);
+    } catch (error) {
+      setMessages(prev => [
+        ...prev,
+        { text: "Ocorreu um erro na busca.", type: "response" }
+      ]);
+    }
+    setInputValue("");
   };
 
   return (
@@ -32,9 +48,21 @@ export const PanelChatBot = () => {
         <div className="search-mode__chat--response">
           {messages
             .filter(m => m.type === "response")
-            .map((msg, i) => (
-              <ChatBubble key={i} type={msg.type} text={msg.text} />
-            ))}
+            .map((msg, i) => {
+              // Pega os documentos correspondentes a esta resposta (3 por grupo)
+              const startIndex = i * 3;
+              const endIndex = startIndex + 3;
+              const currentResults = documents.slice(startIndex, endIndex);
+
+              return (
+                <ChatBubble
+                  key={i}
+                  type={msg.type}
+                  text={msg.text}
+                  results={currentResults}
+                />
+              );
+            })}
         </div>
         <div className="search-mode__chat--query">
           {messages


### PR DESCRIPTION
What I did:

Integrated the chat input system with the actual semantic search API endpoint.

Now, when a user sends a message in the chat, the frontend sends the query to the semantic search backend.

The chat displays the real API response as the assistant's reply.

Why I did it:
To replace the previous mock response system with real, production-ready semantic search functionality, providing users with meaningful and contextually relevant answers.

How to test it:

Open the chat UI.

Type a message (e.g., a question or search phrase).

Verify that the system sends the query to the backend semantic search endpoint.

Confirm that the response from the API appears as the assistant's reply in the chat.