### PR TITLE
feat: add loading components and integrate them into WikiViewer, sear…

### DIFF
--- a/front-end/src/components/ChatBotLoading.tsx
+++ b/front-end/src/components/ChatBotLoading.tsx
@@ -1,0 +1,3 @@
+export const ChatbBotLoading = () => {
+  return <div className="chat-bot-loader"></div>;
+};

--- a/front-end/src/components/Loading.tsx
+++ b/front-end/src/components/Loading.tsx
@@ -1,0 +1,7 @@
+export const Loading = () => {
+  return (
+    <div className="loader">
+      
+    </div>
+  )
+}

--- a/front-end/src/components/PanelChatBot.tsx
+++ b/front-end/src/components/PanelChatBot.tsx
@@ -13,6 +13,7 @@ export const PanelChatBot = () => {
   const [messages, setMessages] = useState<Message[]>([]);
   const [inputValue, setInputValue] = useState("");
   const [documents, setDocuments] = useState<Result[]>([]);
+  const [loading, setLoading] = useState(false);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -33,6 +34,7 @@ export const PanelChatBot = () => {
           type: "response"
         }
       ]);
+      setLoading(false);
     } catch (error) {
       setMessages(prev => [
         ...prev,
@@ -63,6 +65,7 @@ export const PanelChatBot = () => {
                 />
               );
             })}
+          {loading && <ChatBubble type="load" />}
         </div>
         <div className="search-mode__chat--query">
           {messages
@@ -86,7 +89,9 @@ export const PanelChatBot = () => {
             <SendHorizonal
               className="input-icon"
               cursor="pointer"
-              onClick={e => handleSubmit(e)}
+              onClick={e => {
+                handleSubmit(e), setLoading(true);
+              }}
             />
           </div>
         </div>

--- a/front-end/src/components/SearchDocument.tsx
+++ b/front-end/src/components/SearchDocument.tsx
@@ -1,11 +1,13 @@
-import chatIcon from '../assets/chat-bot-icon.png'
+import chatIcon from "../assets/chat-bot-icon.png";
+import { ChatbBotLoading } from "./ChatBotLoading";
 export const SearchDocument = () => {
   return (
     <div className="search-document__bubble">
       <img src={chatIcon} alt="" />
       <div className="chat-bubble">
-        <p className="typing-effect">Pesquisando por documentos</p>
+        {/* <p className="typing-effect">Pesquisando por documentos</p> */}
+        <ChatbBotLoading />
       </div>
     </div>
-  )
-}
+  );
+};

--- a/front-end/src/index.css
+++ b/front-end/src/index.css
@@ -1096,7 +1096,7 @@ body.dark-theme .math-topics__card-item--text p {
 
 .footer {
   background-color: #020422;
-  margin-top: 60px;
+  margin-top: 80px;
   display: flex;
   justify-content: space-between;
   height: 130px;
@@ -1143,6 +1143,48 @@ body.dark-theme .math-topics__card-item--text p {
   -webkit-backdrop-filter: blur(10px);
 }
 
+.loader {
+  width: 50px;
+  padding: 8px;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  background: #41469a;
+  --_m: conic-gradient(#0000 10%, #000), linear-gradient(#000 0 0) content-box;
+  -webkit-mask: var(--_m);
+  mask: var(--_m);
+  -webkit-mask-composite: source-out;
+  mask-composite: subtract;
+  animation: l3 1s infinite linear;
+}
+@keyframes l3 {
+  to {
+    transform: rotate(1turn);
+  }
+}
+
+.chat-bot-loader {
+  width: 45px;
+  aspect-ratio: 2;
+  --_g: no-repeat radial-gradient(circle closest-side, #cccccc 90%, #0000);
+  background: var(--_g) 0% 50%, var(--_g) 50% 50%, var(--_g) 100% 50%;
+  background-size: calc(100% / 3) 50%;
+  animation: l4 1s infinite linear;
+}
+
+@keyframes l4 {
+  20% {
+    background-position: 0% 0%, 50% 50%, 100% 50%;
+  }
+  40% {
+    background-position: 0% 100%, 50% 0%, 100% 50%;
+  }
+  60% {
+    background-position: 0% 50%, 50% 100%, 100% 0%;
+  }
+  80% {
+    background-position: 0% 50%, 50% 50%, 100% 100%;
+  }
+}
 .result-page--wrapper {
   width: 100%;
   display: flex;
@@ -1317,6 +1359,13 @@ body.light-theme .results__item--go-link p {
 }
 
 /* Wikipedia viewer */
+
+.wiki-loading-container {
+  width: 100%;
+  display: flex;
+  align-itens: center;
+  justify-content: center;
+}
 
 .wiki-background {
   border: 2px solid rgba(255, 255, 255, 0.1);

--- a/front-end/src/pages/ResultsPage.tsx
+++ b/front-end/src/pages/ResultsPage.tsx
@@ -1,29 +1,32 @@
-import { SearchBar } from '../components/SearchBar'
-import { ResultDocument } from '../components/ResultDocument'
-import { useEffect, useState } from 'react'
-import { Pagination } from '../components/Pagination'
-import { useSearchParams } from 'react-router-dom'
-import { searchDocs, type Result } from '../api-client/elastic'
-import blackHole from '../assets/black-hole.png'
+import { SearchBar } from "../components/SearchBar";
+import { ResultDocument } from "../components/ResultDocument";
+import { useEffect, useState } from "react";
+import { Pagination } from "../components/Pagination";
+import { useSearchParams } from "react-router-dom";
+import { searchDocs, type Result } from "../api-client/elastic";
+import blackHole from "../assets/black-hole.png";
+import { Loading } from "../components/Loading";
 
 export const ResultPages = () => {
-  const [searchParams, setSearchParams] = useSearchParams()
-  const query = searchParams.get('query') || ''
-  const page = parseInt(searchParams.get('page') || '1', 10)
-  const pageSize = parseInt(searchParams.get('pageSize') || '10', 10)
+  const [searchParams, setSearchParams] = useSearchParams();
+  const query = searchParams.get("query") || "";
+  const page = parseInt(searchParams.get("page") || "1", 10);
+  const pageSize = parseInt(searchParams.get("pageSize") || "10", 10);
+  const [isLoading, setIsLoading] = useState(true);
 
-  const [results, setResults] = useState<Result[]>([])
-  const [total, setTotal] = useState(0)
+  const [results, setResults] = useState<Result[]>([]);
+  const [total, setTotal] = useState(0);
 
   useEffect(() => {
     const fetchDocuments = async () => {
-      const response = await searchDocs(query, page, pageSize)
-      setResults(response.results)
-      setTotal(response.total)
-    }
+      const response = await searchDocs(query, page, pageSize);
+      setResults(response.results);
+      setTotal(response.total);
+      setIsLoading(false);
+    };
 
-    fetchDocuments()
-  }, [query, page, pageSize])
+    fetchDocuments();
+  }, [query, page, pageSize]);
 
   const updatePagination = (
     newPage: number,
@@ -33,10 +36,10 @@ export const ResultPages = () => {
       query,
       page: newPage.toString(),
       pageSize: newPageSize.toString()
-    })
-  }
+    });
+  };
 
-  const numberPages = Math.ceil(total / pageSize)
+  const numberPages = Math.ceil(total / pageSize);
 
   return (
     <>
@@ -47,7 +50,7 @@ export const ResultPages = () => {
             {[5, 10, 15].map(size => (
               <button
                 key={size}
-                className={pageSize === size ? 'active' : ''}
+                className={pageSize === size ? "active" : ""}
                 onClick={() => updatePagination(1, size)}
               >
                 {size}
@@ -64,24 +67,30 @@ export const ResultPages = () => {
           </div>
           <SearchBar />
         </div>
-        <div className="query-container">
-          <h1 className="results__query">{query}</h1>
-          <p className="total-results">Total Results: {total}</p>
-        </div>
-        <div className="results-item__container">
-          {results.map(item => (
-            <ResultDocument key={item._id} result={item} />
-          ))}
-        </div>
+        {isLoading ? (
+          <Loading />
+        ) : (
+          <>
+            <div className="query-container">
+              <h1 className="results__query">{query}</h1>
+              <p className="total-results">Total Results: {total}</p>
+            </div>
+            <div className="results-item__container">
+              {results.map(item => (
+                <ResultDocument key={item._id} result={item} />
+              ))}
+            </div>
 
-        <Pagination
-          changePage={(newPage: number) => updatePagination(newPage)}
-          numPages={numberPages}
-          page={page}
-          pageInfo={true}
-          showNumbers={true}
-        />
+            <Pagination
+              changePage={(newPage: number) => updatePagination(newPage)}
+              numPages={numberPages}
+              page={page}
+              pageInfo={true}
+              showNumbers={true}
+            />
+          </>
+        )}
       </div>
     </>
-  )
-}
+  );
+};

--- a/front-end/src/pages/WikiViewer.tsx
+++ b/front-end/src/pages/WikiViewer.tsx
@@ -1,34 +1,46 @@
-import { useEffect, useState } from 'react'
-import { ScrollText, Route, Star } from 'lucide-react'
-import { SearchBar } from '../components/SearchBar'
-import { useLocation, useParams } from 'react-router-dom'
-import { addNumViewDoc } from '../api-client/elastic'
+import { useEffect, useState } from "react";
+import { ScrollText, Route, Star } from "lucide-react";
+import { SearchBar } from "../components/SearchBar";
+import { useLocation, useParams } from "react-router-dom";
+import { addNumViewDoc } from "../api-client/elastic";
+import { Loading } from "../components/Loading";
 
 export const WikiViewer = () => {
-  const location = useLocation()
-  const documentId = location.state?.id
-  const [htmlContent, setHtmlContent] = useState('')
-  const { title } = useParams()
+  const location = useLocation();
+  const documentId = location.state?.id;
+  const [htmlContent, setHtmlContent] = useState("");
+  const [isLoading, setIsLoading] = useState(true);
+  const { title } = useParams();
 
   useEffect(() => {
+    if (!title) return;
     const fetchWiki = async () => {
-      const response = await fetch(
-        `https://en.wikipedia.org/api/rest_v1/page/html/${title}`
-      )
-      let html = await response.text()
+      try {
+        setIsLoading(true);
+        const response = await fetch(
+          `https://en.wikipedia.org/api/rest_v1/page/html/${title}`
+        );
+        let html = await response.text();
 
-      html = html.replace(/<\/?(html|body|base)[^>]*>/gi, '')
-      html = html.replace(/<a [^>]*>/gi, '')
-      html = html.replace(/<\/a>/gi, '')
+        html = html.replace(/<\/?(html|body|base)[^>]*>/gi, "");
+        html = html.replace(/<a [^>]*>/gi, "");
+        html = html.replace(/<\/a>/gi, "");
 
-      setHtmlContent(html)
-      await addNumViewDoc(documentId)
-    }
+        setHtmlContent(html);
+        await addNumViewDoc(documentId);
+      } catch (error) {
+        console.error("Error fetching wiki content:", error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
 
-    fetchWiki()
-  }, [title, documentId])
+    fetchWiki();
+  }, [title, documentId]);
 
-  if (!title) return
+  if (!title) {
+    return <div>No title provided</div>;
+  }
 
   return (
     <>
@@ -38,25 +50,33 @@ export const WikiViewer = () => {
         </span>
       </div>
 
-      <div className="wiki-background">
-        <div className="wiki">
-          <div className="wiki__header">
-            <h2>{title.replace(/_/g, ' ')}</h2>
-            <div className="wiki__header--menu">
-              <ScrollText className="menu-item" />
-              <Route className="menu-item" />
-              <Star className="menu-item" />
+      {isLoading ? (
+        <div className="wiki-loading-container">
+          <Loading />
+        </div>
+      ) : (
+        <>
+          <div className="wiki-background">
+            <div className="wiki">
+              <div className="wiki__header">
+                <h2>{title.replace(/_/g, " ")}</h2>
+                <div className="wiki__header--menu">
+                  <ScrollText className="menu-item" />
+                  <Route className="menu-item" />
+                  <Star className="menu-item" />
+                </div>
+              </div>
+
+              <div
+                className="wiki__content"
+                dangerouslySetInnerHTML={{ __html: htmlContent }}
+              >
+                {}
+              </div>
             </div>
           </div>
-
-          <div
-            className="wiki__content"
-            dangerouslySetInnerHTML={{ __html: htmlContent }}
-          >
-            {}
-          </div>
-        </div>
-      </div>
+        </>
+      )}
     </>
-  )
-}
+  );
+};


### PR DESCRIPTION
What I did:

Created two new loading components:
→ Full-screen loading component (for pages like WikiViewer and search results).
→ Chatbot response loading indicator (to show loading state while waiting for API responses in the chat).

Integrated the loading components into:

The WikiViewer page (document details view).

The search results page.

The chatbot, showing a loading indicator while waiting for semantic search responses.

Why I did it:
To improve user experience by providing visual feedback during data loading processes and API calls.

How to test it:

Navigate to the WikiViewer page and trigger a document load → Verify that the full-screen loader appears while loading.

Perform a search → Check that the search results page shows a loading indicator during the request.

Send a message in the chatbot → Confirm that a loading animation appears while waiting for the API reply.