### PR TITLE
Improve document navigation and fix theme-based image display

### DIFF
--- a/back-end/api.http
+++ b/back-end/api.http
@@ -1,14 +1,14 @@
 ###
-GET http://localhost:3333/wikipedia/search?query=quadratic+equation&page=1&pageSize=10
+GET http://localhost:3333/wikipedia/search?query=ellipse&page=1&pageSize=10
 
 ###
-GET http://localhost:3333/wikipedia/332
+GET http://localhost:3333/wikipedia/2258
 
 ###
-GET http://localhost:3333/wikipedia/mostViews/9
+GET http://localhost:3333/wikipedia/mostViews/10
 
 ###
-PATCH http://localhost:3333/wikipedia/increment/332
+PATCH http://localhost:3333/wikipedia/increment/13364
 
 ###
 POST http://localhost:3333/wikipedia/semantic_search

--- a/front-end/src/api-client/elastic.ts
+++ b/front-end/src/api-client/elastic.ts
@@ -37,5 +37,5 @@ export const semanticSearch = async (query: string): Promise<Results> => {
 };
 
 export const addNumViewDoc = async (id: string) => {
-  await API.get(`/wikipedia/increment/${id}`);
+  await API.patch(`/wikipedia/increment/${id}`);
 };

--- a/front-end/src/components/ChatBubble.tsx
+++ b/front-end/src/components/ChatBubble.tsx
@@ -3,6 +3,7 @@ import { UserCircle2, LinkIcon } from "lucide-react";
 import chatIcon from "../assets/chat-bot-icon.png";
 import { SearchDocument } from "./SearchDocument";
 import type { Result } from "../api-client/elastic";
+import { Link } from "react-router-dom";
 
 type ChatBubbleProps = {
   type: "response" | "query" | "load";
@@ -26,11 +27,11 @@ export const ChatBubble = ({ type, text, results }: ChatBubbleProps) => {
             {text}
             {results && results.length > 0 && (
               <div className="bot-results">
-                {results.map((item, index) => (
-                  <span key={index}>
+                {results.map(item => (
+                  <Link to={`/wiki/${item.title}`} target="_blank">
                     <LinkIcon size={10} />
                     {item.title}
-                  </span>
+                  </Link>
                 ))}
               </div>
             )}

--- a/front-end/src/components/SearchDocument.tsx
+++ b/front-end/src/components/SearchDocument.tsx
@@ -5,7 +5,6 @@ export const SearchDocument = () => {
     <div className="search-document__bubble">
       <img src={chatIcon} alt="" />
       <div className="chat-bubble">
-        {/* <p className="typing-effect">Pesquisando por documentos</p> */}
         <ChatbBotLoading />
       </div>
     </div>

--- a/front-end/src/index.css
+++ b/front-end/src/index.css
@@ -762,23 +762,23 @@ body.light-theme .panel__shortcuts--card p {
   color: #5c62cd;
 }
 
-.bot-results span {
-  cursor: pointer;
+.bot-results a {
+  color: #5c62cd;
 }
 
-body.light-theme .bot-results span {
+body.light-theme .bot-results a {
   color: rgb(52, 59, 176);
 }
 
-.bot-results span svg {
+.bot-results a svg {
   margin-right: 2px;
 }
 
-.bot-results span:hover {
+.bot-results a:hover {
   color: rgb(127, 132, 237);
 }
 
-body.light-theme .bot-results span:hover {
+body.light-theme .bot-results a:hover {
   color: rgb(10, 15, 116);
 }
 

--- a/front-end/src/index.css
+++ b/front-end/src/index.css
@@ -918,6 +918,12 @@ body.dark-theme .typing-effect {
   transform: translateY(2%);
 }
 
+body.light-theme .black-hole-container .black-hole-white-result {
+  position: absolute;
+  width: 20%;
+  margin-left: 15px;
+}
+
 .black-hole-container .black-hole-white {
   transform: translateY(-2%);
 }

--- a/front-end/src/pages/ResultsPage.tsx
+++ b/front-end/src/pages/ResultsPage.tsx
@@ -1,11 +1,13 @@
 import { SearchBar } from "../components/SearchBar";
 import { ResultDocument } from "../components/ResultDocument";
-import { useEffect, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import { Pagination } from "../components/Pagination";
 import { useSearchParams } from "react-router-dom";
 import { searchDocs, type Result } from "../api-client/elastic";
 import blackHole from "../assets/black-hole.png";
+import blackHoleWhite from "../assets/black-hole-white.png";
 import { Loading } from "../components/Loading";
+import { ThemeContext } from "../context/ThemeContext";
 
 export const ResultPages = () => {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -16,6 +18,7 @@ export const ResultPages = () => {
 
   const [results, setResults] = useState<Result[]>([]);
   const [total, setTotal] = useState(0);
+  const { isLight } = useContext(ThemeContext);
 
   useEffect(() => {
     const fetchDocuments = async () => {
@@ -63,7 +66,15 @@ export const ResultPages = () => {
       <div className="results-container">
         <div className="search-container">
           <div className="black-hole-container">
-            <img src={blackHole} alt="black hole" className="black-hole" />
+            {isLight ? (
+              <img
+                src={blackHoleWhite}
+                alt="black hole"
+                className="black-hole-white-result"
+              />
+            ) : (
+              <img src={blackHole} alt="black hole" className="black-hole" />
+            )}
           </div>
           <SearchBar />
         </div>

--- a/front-end/src/pages/WikiViewer.tsx
+++ b/front-end/src/pages/WikiViewer.tsx
@@ -12,6 +12,8 @@ export const WikiViewer = () => {
   const [isLoading, setIsLoading] = useState(true);
   const { title } = useParams();
 
+  console.log(documentId);
+
   useEffect(() => {
     if (!title) return;
     const fetchWiki = async () => {


### PR DESCRIPTION
What I did:
Grouped three frontend improvements and fixes related to UX and navigation:

Fix: Adjust search panel image based on theme (light/dark)

Added conditional logic to dynamically switch the search panel image depending on whether the user is in light or dark mode.

Feat: Include document links in chatbot semantic search responses

Enhanced the chatbot’s semantic search responses by including clickable links for each returned document, making navigation to document pages possible directly from the chat.

Fix: Ensure document view updates correctly when selecting a new document

Fixed a bug where the WikiViewer page did not update the displayed document when users clicked on different documents from search or chat results.

Why I did it:
To improve the user experience by:

Ensuring correct image display across themes.

Allowing easier navigation to document pages via the chatbot.

Fixing document view updates when selecting documents from different sources.