### PR TITLE
style: add initial empty state screen for chatbot and improve light t…

### DIFF
--- a/front-end/src/components/PanelChatBot.tsx
+++ b/front-end/src/components/PanelChatBot.tsx
@@ -3,6 +3,7 @@ import { ChatBubble } from "./ChatBubble";
 import { useState } from "react";
 import { semanticSearch } from "../api-client/elastic";
 import type { Result } from "../api-client/elastic";
+import chatIcon from "../assets/chat-bot-icon.png";
 
 type Message = {
   text: string;
@@ -14,6 +15,7 @@ export const PanelChatBot = () => {
   const [inputValue, setInputValue] = useState("");
   const [documents, setDocuments] = useState<Result[]>([]);
   const [loading, setLoading] = useState(false);
+  const [send, setSend] = useState(false);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -47,33 +49,49 @@ export const PanelChatBot = () => {
   return (
     <div className="panel__search-mode">
       <div className="search-mode__chat">
-        <div className="search-mode__chat--response">
-          {messages
-            .filter(m => m.type === "response")
-            .map((msg, i) => {
-              // Pega os documentos correspondentes a esta resposta (3 por grupo)
-              const startIndex = i * 3;
-              const endIndex = startIndex + 3;
-              const currentResults = documents.slice(startIndex, endIndex);
+        {messages.length === 0 && (
+          <div className="chat-initial__container">
+            <div className="chat-initial__title">
+              <img src={chatIcon} alt="chat icon" height={30} width={30} />
+              <h3>Search with AI:</h3>
+            </div>
+            <p>
+              The system understands the meaning behind your words, not just the
+              exact text.
+            </p>
+          </div>
+        )}
+        {send && (
+          <>
+            <div className="search-mode__chat--response">
+              {messages
+                .filter(m => m.type === "response")
+                .map((msg, i) => {
+                  // Pega os documentos correspondentes a esta resposta (3 por grupo)
+                  const startIndex = i * 3;
+                  const endIndex = startIndex + 3;
+                  const currentResults = documents.slice(startIndex, endIndex);
 
-              return (
-                <ChatBubble
-                  key={i}
-                  type={msg.type}
-                  text={msg.text}
-                  results={currentResults}
-                />
-              );
-            })}
-          {loading && <ChatBubble type="load" />}
-        </div>
-        <div className="search-mode__chat--query">
-          {messages
-            .filter(m => m.type === "query")
-            .map((msg, i) => (
-              <ChatBubble key={i} type={msg.type} text={msg.text} />
-            ))}
-        </div>
+                  return (
+                    <ChatBubble
+                      key={i}
+                      type={msg.type}
+                      text={msg.text}
+                      results={currentResults}
+                    />
+                  );
+                })}
+              {loading && <ChatBubble type="load" />}
+            </div>
+            <div className="search-mode__chat--query">
+              {messages
+                .filter(m => m.type === "query")
+                .map((msg, i) => (
+                  <ChatBubble key={i} type={msg.type} text={msg.text} />
+                ))}
+            </div>
+          </>
+        )}
       </div>
 
       <div className="input-wrapper">
@@ -90,7 +108,7 @@ export const PanelChatBot = () => {
               className="input-icon"
               cursor="pointer"
               onClick={e => {
-                handleSubmit(e), setLoading(true);
+                handleSubmit(e), setLoading(true), setSend(true);
               }}
             />
           </div>

--- a/front-end/src/index.css
+++ b/front-end/src/index.css
@@ -715,6 +715,7 @@ body.light-theme .panel__shortcuts--card p {
 .search-mode__chat--response {
   width: 40%;
 }
+
 .chat-bubble {
   margin-top: 3%;
   padding: 15px;
@@ -724,6 +725,10 @@ body.light-theme .panel__shortcuts--card p {
   width: fit-content;
   color: white;
   max-width: 200px;
+}
+
+body.light-theme .chat-bubble {
+  background-color: rgb(179, 179, 185);
 }
 
 .chat--query-item {
@@ -750,8 +755,41 @@ body.light-theme .panel__shortcuts--card p {
   border-radius: 0 25px 25px 25px;
 }
 
+.chat-initial__container {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.chat-initial__container h3 {
+  font-family: var(--font);
+  font-size: 35px;
+}
+
+.chat-initial__container p {
+  font-family: var(--font);
+}
+
+.chat-initial__title {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+}
+
+.chat-initial__title img {
+  box-shadow: 0 0 8px rgba(0, 0, 0, 0.3), 0 2px 16px rgba(0, 0, 0, 0.3);
+  border-radius: 30px;
+}
+
 .chat--response-item {
   margin-top: 50px;
+}
+
+body.light-theme .chat--response-item img {
+  box-shadow: 0 0 8px rgba(0, 0, 0, 0.3), 0 2px 16px rgba(0, 0, 0, 0.3);
+  border-radius: 30px;
 }
 
 .bot-results {
@@ -767,7 +805,7 @@ body.light-theme .panel__shortcuts--card p {
 }
 
 body.light-theme .bot-results a {
-  color: rgb(52, 59, 176);
+  color: rgb(48, 52, 170);
 }
 
 .bot-results a svg {


### PR DESCRIPTION
What I did:

Added an initial empty state screen for the chatbot when there are no messages, improving the user experience on first access.

Improved the styling for the light theme version of the chatbot, making the visual appearance more consistent and user-friendly.

Why I did it:
To enhance the user experience by providing visual feedback when the chat is empty and to improve the overall readability and aesthetic of the chatbot under the light theme.

How to test it:

Open the chatbot with no messages → Confirm that the new initial screen appears (e.g., with a welcome message or placeholder image/text).

Switch to light theme → Verify that the chatbot styling looks cleaner and consistent with the rest of the UI.