### PR TITLE
fix: display no results message when search returns empty and fix foo…

### DIFF
--- a/front-end/src/components/Footer.tsx
+++ b/front-end/src/components/Footer.tsx
@@ -1,5 +1,5 @@
-import { Copyright } from 'lucide-react'
-import piLogo from '../assets/piLogo.png'
+import { Copyright } from "lucide-react";
+import piLogo from "../assets/piLogo.png";
 export const Footer = () => {
   return (
     <div className="footer">
@@ -12,5 +12,5 @@ export const Footer = () => {
         <p>2025 MathSeek. All rights reserved.</p>
       </div>
     </div>
-  )
-}
+  );
+};

--- a/front-end/src/components/PanelChatBot.tsx
+++ b/front-end/src/components/PanelChatBot.tsx
@@ -32,7 +32,7 @@ export const PanelChatBot = () => {
       setMessages(prev => [
         ...prev,
         {
-          text: "Aqui estão alguns resultados:",
+          text: "Here are some results:",
           type: "response"
         }
       ]);
@@ -40,8 +40,9 @@ export const PanelChatBot = () => {
     } catch (error) {
       setMessages(prev => [
         ...prev,
-        { text: "Ocorreu um erro na busca.", type: "response" }
+        { text: "An error occurred while searching", type: "response" }
       ]);
+      setLoading(false);
     }
     setInputValue("");
   };

--- a/front-end/src/index.css
+++ b/front-end/src/index.css
@@ -21,6 +21,19 @@
   padding: 0;
 }
 
+html,
+body {
+  height: 100%;
+  margin: 0;
+  padding: 0;
+}
+
+#root {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
 a {
   text-decoration: none;
 }
@@ -1053,6 +1066,14 @@ body.light-theme .black-hole-container .black-hole-white-result {
   border-radius: 3px;
 }
 
+.pagination__info input:focus {
+  outline: var(--border-dark);
+}
+
+body.light-theme .pagination__info input:focus {
+  outline: var(--border-light);
+}
+
 body.light-theme .pagination__info input {
   background-color: var(--default-border-color-light);
   color: rgba(0, 0, 0, 0.7);
@@ -1146,6 +1167,9 @@ body.dark-theme .math-topics__card-item--text p {
 /* Footer */
 
 .footer {
+  margin-top: auto;
+  text-align: center;
+  width: 100%;
   background-color: #020422;
   margin-top: 80px;
   display: flex;
@@ -1237,6 +1261,7 @@ body.dark-theme .math-topics__card-item--text p {
   }
 }
 .result-page--wrapper {
+  flex: 1;
   width: 100%;
   display: flex;
   align-items: center;
@@ -1315,6 +1340,7 @@ body.light-theme .result-page__number-of-results__buttons .active {
   display: flex;
   flex-direction: column;
   align-items: center;
+  flex: 1;
 }
 
 .query-container {

--- a/front-end/src/pages/ResultsPage.tsx
+++ b/front-end/src/pages/ResultsPage.tsx
@@ -1,7 +1,7 @@
 import { ResultDocument } from "../components/ResultDocument";
 import { useContext, useEffect, useState } from "react";
 import { Pagination } from "../components/Pagination";
-import { useSearchParams } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { searchDocs, type Result } from "../api-client/elastic";
 import blackHole from "../assets/black-hole.png";
 import blackHoleWhite from "../assets/black-hole-white.png";
@@ -10,6 +10,7 @@ import { ThemeContext } from "../context/ThemeContext";
 import { SearchBar } from "../components/SearchBar";
 
 export const ResultPages = () => {
+  const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const query = searchParams.get("query") || "";
   const page = parseInt(searchParams.get("page") || "1", 10);
@@ -19,6 +20,26 @@ export const ResultPages = () => {
   const [results, setResults] = useState<Result[]>([]);
   const [total, setTotal] = useState(0);
   const { isLight } = useContext(ThemeContext);
+
+  useEffect(() => {
+    if (isNaN(page) || page <= 0) {
+      navigate(`/search?query=${query}&page=1&pageSize=10`, {
+        replace: true
+      });
+    }
+
+    if (isNaN(pageSize) || pageSize <= 0) {
+      navigate(`/search?query=${query}&page=${page}&pageSize=10`, {
+        replace: true
+      });
+    }
+
+    if (pageSize > 100) {
+      navigate(`/search?query=${query}&page=${page}&pageSize=100`, {
+        replace: true
+      });
+    }
+  }, [page, pageSize, navigate]);
 
   useEffect(() => {
     const fetchDocuments = async () => {
@@ -80,7 +101,7 @@ export const ResultPages = () => {
         </div>
         {isLoading ? (
           <Loading />
-        ) : (
+        ) : total > 0 ? (
           <>
             <div className="query-container">
               <h1 className="results__query">{query}</h1>
@@ -100,6 +121,10 @@ export const ResultPages = () => {
               showNumbers={true}
             />
           </>
+        ) : (
+          <div className="query-container">
+            <h1 className="results__query">No Results</h1>
+          </div>
         )}
       </div>
     </>


### PR DESCRIPTION
What I did:

Added a "No results" message to be displayed when the search query returns no documents.

Fixed a layout issue where the footer appeared in the middle of the screen on small screen sizes.

Why I did it:
To improve user feedback during empty search results and to correct a layout bug that was affecting the footer display on mobile and smaller devices.