### PR TITLE
feat: connect add to favorites API route to frontend

### DIFF
--- a/back-end/api.http
+++ b/back-end/api.http
@@ -76,16 +76,16 @@ Content-Type: application/json
 
 ###
 GET http://localhost:3333/users/me/favorites
-Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImFkbWluMiIsImlkIjoiNjgzODY4YWJlNDRkM2UzNjk1M2U4NmJkIiwiaWF0IjoxNzQ5NDc1MjMxLCJleHAiOjE3NDk0NzU0MTF9.S3Fqw28mzboU8PvAe9OAJ0U32rlkVKJvtCJXVlcWc8Y
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImFkbWluMzQiLCJpZCI6IjY4NGI2ZWY3NDhmMmE1N2ExMjBmZTAyYiIsImlhdCI6MTc1MDk4MjQ4NywiZXhwIjoxNzUwOTgzMzg3fQ.PIruuE7MdQLOBw4ectHlbvP7rDCThO-l81ac2-AYu9E
 
 ###
 PATCH http://localhost:3333/users/me/favorites
-Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImFkbWluemFkYSIsImlkIjoiNjg0ZGJkMTdmNjAzNTEwYzA5NjM5MTM4IiwiaWF0IjoxNzQ5OTM0NTYzLCJleHAiOjE3NDk5MzQ3NDN9.ITkEt4eAZ5J_WjVBGmLPzQzcVOX6hVixBFwF53Ol_k8
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImFkbWluMzQiLCJpZCI6IjY4NGI2ZWY3NDhmMmE1N2ExMjBmZTAyYiIsImlhdCI6MTc1MDk4NzA1MiwiZXhwIjoxNzUwOTg3OTUyfQ.UhnlSM4R6jlLyz2tVQrMFy-T50Om3bg7YNMjkqsfIag
 Content-Type: application/json
 
 {
-  "favorite": 11,
-  "type": "add"
+  "favorite": 3,
+  "type": "remove"
 } 
 
 ###

--- a/back-end/package.json
+++ b/back-end/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@elastic/elasticsearch": "^8.0.0",
     "@fastify/cors": "^11.0.1",
+    "@fastify/formbody": "^8.0.2",
     "@fastify/jwt": "^9.1.0",
     "@fastify/swagger": "^9.4.2",
     "@fastify/swagger-ui": "^5.2.2",

--- a/back-end/src/controllers/favorite.controller.ts
+++ b/back-end/src/controllers/favorite.controller.ts
@@ -21,6 +21,14 @@ export const getFavoriteController = async (request, reply) => {
 export const updateFavoriteController = async (request, reply) => {
   const userId = request.user?.id;
   const { favorite, type } = request.body;
+
+  if (!favorite || !type) {
+    console.log("Invalid payload structure:", { favorite, type });
+    return reply.code(400).send({
+      message: "Payload must contain {favorite: number, type: string}"
+    });
+  }
+
   try {
     const updateUser = await addOrRemoveFavoriteService(userId, favorite, type);
     return reply.code(200).send(updateUser);

--- a/back-end/src/routes/favorite.route.ts
+++ b/back-end/src/routes/favorite.route.ts
@@ -41,7 +41,7 @@ export function favoriteRoute(app) {
         description: "",
         tags: [""],
         body: z.object({
-          favorite: updateFavoriteDto,
+          favorite: z.number(),
           type: z.string()
         }),
         response: {

--- a/back-end/src/server.ts
+++ b/back-end/src/server.ts
@@ -20,13 +20,14 @@ import { folderRoute } from "./routes/folder.route";
 import { generalSettingsRoute } from "./routes/generalSettings.route";
 import { cardSettingsRoute } from "./routes/cardSettings.route";
 import { semanticSearch } from "./routes/semanticSearch.route";
-
+import formBody from "@fastify/formbody";
 // criando conexao com mongo
 
 connectDb();
 
 const app = fastify();
 
+app.register(formBody);
 app.register(signRoute);
 app.register(loginRoute);
 app.register(profile);
@@ -37,14 +38,15 @@ app.register(shortcutRoute);
 app.register(folderRoute);
 app.register(generalSettingsRoute);
 app.register(cardSettingsRoute);
-app.register(semanticSearch)
+app.register(semanticSearch);
 
 app.setValidatorCompiler(validatorCompiler);
 app.setSerializerCompiler(serializerCompiler);
 
 app.register(cors, {
   origin: "http://localhost:5173",
-  methods: ["GET", "POST", "DELETE", "PUT", "PATCH"]
+  methods: ["GET", "POST", "DELETE", "PUT", "PATCH"],
+  allowedHeaders: ["Content-Type", "Authorization"]
 });
 
 app.register(fastifySwagger, {

--- a/front-end/src/api-client/api.ts
+++ b/front-end/src/api-client/api.ts
@@ -18,7 +18,6 @@ API.interceptors.request.use(config => {
   return config;
 });
 
-// Interceptor para tratar erros de token expirado
 API.interceptors.response.use(
   response => response,
   async error => {

--- a/front-end/src/api-client/favorite.ts
+++ b/front-end/src/api-client/favorite.ts
@@ -7,14 +7,6 @@ export const getFavorites = async (favorites: number[] | undefined) => {
   return responses.map(response => response.data);
 };
 
-export const addToFavorites = async (documentId: number) => {
-  const response = await API.patch("/users/me/favorites", {
-    favorite: documentId,
-    type: "add"
-  });
-  return response.data;
-};
-
 export const removeFromFavorites = async (documentId: number) => {
   const response = await API.patch("/users/me/favorites", {
     favorite: documentId,
@@ -22,3 +14,36 @@ export const removeFromFavorites = async (documentId: number) => {
   });
   return response.data;
 };
+
+export const addToFavorites = async (documentId: number) => {
+  const payload = {
+    favorite: documentId,
+    type: "add"
+  };
+
+  try {
+    return await API.patch("/users/me/favorites", payload);
+  } catch (error) {
+    console.error("DIRECT FETCH ERROR:", error);
+  }
+};
+// export const addToFavorites = async (favorite: number) => {
+//   const testPayload = {
+//     favorite: 11,
+//     type: "add"
+//   };
+
+//   try {
+//     const res = await fetch("http://localhost:3333/users/me/favorites", {
+//       method: "PATCH",
+//       headers: {
+//         "Content-Type": "application/json",
+//         Authorization: `Bearer ${sessionStorage.getItem("accessToken")}`
+//       },
+//       body: JSON.stringify(testPayload)
+//     });
+//     console.log("TEST RESPONSE:", await res.json());
+//   } catch (error) {
+//     console.error("DIRECT FETCH ERROR:", error);
+//   }
+// };

--- a/front-end/src/index.css
+++ b/front-end/src/index.css
@@ -287,6 +287,16 @@ body.light-theme .sidebar-search-mode .search__side-bar {
   cursor: pointer;
 }
 
+.menu-button {
+  background: none;
+  color: white;
+  border: none;
+}
+
+body.light-theme .menu-button {
+  color: black;
+}
+
 .side-bar--menu-item:hover {
   background-color: #535557;
 }

--- a/front-end/src/pages/WikiViewer.tsx
+++ b/front-end/src/pages/WikiViewer.tsx
@@ -4,6 +4,7 @@ import { useLocation, useParams } from "react-router-dom";
 import { addNumViewDoc } from "../api-client/elastic";
 import { Loading } from "../components/Loading";
 import { SearchBar } from "../components/SearchBar";
+import { addToFavorites } from "../api-client/favorite";
 
 export const WikiViewer = () => {
   const location = useLocation();
@@ -11,6 +12,14 @@ export const WikiViewer = () => {
   const [htmlContent, setHtmlContent] = useState("");
   const [isLoading, setIsLoading] = useState(true);
   const { title } = useParams();
+
+  const handleAddFavorite = async () => {
+    try {
+      await addToFavorites(parseInt(documentId));
+    } catch (error) {
+      console.error(error);
+    }
+  };
 
   useEffect(() => {
     if (!title) return;
@@ -63,7 +72,9 @@ export const WikiViewer = () => {
                 <div className="wiki__header--menu">
                   <ScrollText className="menu-item" />
                   <Route className="menu-item" />
-                  <Star className="menu-item" />
+                  <button className="menu-button" onClick={handleAddFavorite}>
+                    <Star className="menu-item" />
+                  </button>
                 </div>
               </div>
 


### PR DESCRIPTION
What I did:

Linked the frontend UI with the backend API route responsible for adding items to the user's favorites.

Now, when a user clicks to favorite an item, a request is sent to the API and the UI updates accordingly.

Why I did it:
To enable users to interact with their favorites directly from the frontend, improving the overall experience and functionality.