### PR TITLE
feat: add expandable menu with redirect mode options via radio buttons

### DIFF
--- a/front-end/src/components/PanelCard.tsx
+++ b/front-end/src/components/PanelCard.tsx
@@ -1,68 +1,71 @@
-import { useState, useContext, useEffect } from 'react'
-import { ThemeContext } from '../context/ThemeContext'
+import { useState, useContext, useEffect } from "react";
+import { ThemeContext } from "../context/ThemeContext";
 import {
   FileSearch,
   BotMessageSquare,
   Cog,
   X,
   ImagePlus,
-  MonitorCog
-} from 'lucide-react'
+  MonitorCog,
+  ChevronDown,
+  ChevronUp
+} from "lucide-react";
 
-import blackHole from '../assets/black-hole.png'
-import blackHoleWhite from '../assets/black-hole-white.png'
-import { PanelSearch } from './PanelSearch'
-import { PanelChatBot } from './PanelChatBot'
+import blackHole from "../assets/black-hole.png";
+import blackHoleWhite from "../assets/black-hole-white.png";
+import { PanelSearch } from "./PanelSearch";
+import { PanelChatBot } from "./PanelChatBot";
 
 export const PanelCard = () => {
-  const [dateTime, setDateTime] = useState(new Date())
-  const [viewSidebar, setViewSidebar] = useState(false)
-  const [sidebarSearchMode, setSidebarSearchMode] = useState(false)
-  const { isLight } = useContext(ThemeContext)
-  const [searchMode, setSearchMode] = useState<'search' | 'chatbot'>('search')
+  const [dateTime, setDateTime] = useState(new Date());
+  const [viewSidebar, setViewSidebar] = useState(false);
+  const [sidebarSearchMode, setSidebarSearchMode] = useState(false);
+  const { isLight } = useContext(ThemeContext);
+  const [searchMode, setSearchMode] = useState<"search" | "chatbot">("search");
+  const [configs, setConfigs] = useState(false);
 
   const months = [
-    'JAN',
-    'FEV',
-    'MAR',
-    'ABR',
-    'MAI',
-    'JUN',
-    'JUL',
-    'AGO',
-    'SET',
-    'OUT',
-    'NOV',
-    'DEZ'
-  ]
+    "JAN",
+    "FEV",
+    "MAR",
+    "ABR",
+    "MAI",
+    "JUN",
+    "JUL",
+    "AGO",
+    "SET",
+    "OUT",
+    "NOV",
+    "DEZ"
+  ];
 
-  const days = ['DOM', 'SEG', 'TER', 'QUA', 'QUI', 'SEX', 'SAB']
+  const days = ["DOM", "SEG", "TER", "QUA", "QUI", "SEX", "SAB"];
 
   const formatDateTime = (type: string) => {
-    if (type === 'day') {
+    if (type === "day") {
       return `${days[dateTime.getDay()]} ${String(dateTime.getDate()).padStart(
         2,
-        '0'
-      )} `
+        "0"
+      )} `;
     }
-    if (type === 'month') {
-      return months[dateTime.getMonth()]
+    if (type === "month") {
+      return months[dateTime.getMonth()];
     }
-    if (type === 'hour') {
-      return `${String(dateTime.getHours()).padStart(2, '0')}:${String(
+    if (type === "hour") {
+      return `${String(dateTime.getHours()).padStart(2, "0")}:${String(
         dateTime.getMinutes()
-      ).padStart(2, '0')}`
+      ).padStart(2, "0")}`;
     }
-    return ''
-  }
+    return "";
+  };
 
   useEffect(() => {
     const interval = setInterval(() => {
-      setDateTime(new Date())
-    }, 60000)
+      setDateTime(new Date());
+    }, 60000);
 
-    return () => clearInterval(interval)
-  }, [])
+    return () => clearInterval(interval);
+  }, []);
 
   return (
     <>
@@ -82,13 +85,16 @@ export const PanelCard = () => {
 
       <div className="container__panel">
         <div className="panel-background">
-          <div className={`${viewSidebar && 'sidebar-blur__active'}`}>
+          <div className={`${viewSidebar && "sidebar-blur__active"}`}>
             <div className="panel__side-bar">
               <div className="panel__side-bar--header">
                 <X
                   className="close-icon"
-                  onClick={() => setViewSidebar(false)}
-                  cursor={'pointer'}
+                  onClick={() => {
+                    setViewSidebar(false);
+                    setConfigs(true);
+                  }}
+                  cursor={"pointer"}
                 />
               </div>
               <div className="side-bar__menu">
@@ -99,10 +105,41 @@ export const PanelCard = () => {
                   </div>
                 </div>
                 <div className="side-bar__menu--items">
-                  <div className="menu--items-container">
+                  <div
+                    className="menu--items-container"
+                    onClick={() => setConfigs(!configs)}
+                  >
                     <MonitorCog />
                     Advanced Configs
+                    {configs ? <ChevronDown /> : <ChevronUp />}
                   </div>
+                </div>
+                <div
+                  className="config-menu"
+                  style={{ opacity: configs ? 0 : 1 }}
+                >
+                  <h3>Results location:</h3>
+                  <div className="config-menu__input-wraper">
+                    <input
+                      type="radio"
+                      id="inline-cards"
+                      value="inline"
+                      name="results-location"
+                      className="radio-input"
+                    />
+                    <label htmlFor="inline-cards">Inline cards</label>
+                  </div>
+                  <div className="config-menu__input-wraper">
+                    <input
+                      type="radio"
+                      id="results-page"
+                      value="page"
+                      name="results-location"
+                      className="radio-input"
+                    />
+                    <label htmlFor="results-page">Dedicated results page</label>
+                  </div>
+                  <button className="config-menu__save">Save</button>
                 </div>
               </div>
             </div>
@@ -112,35 +149,35 @@ export const PanelCard = () => {
               <div className="panel__header--mode">
                 <div
                   className={`panel__header--mode-item ${
-                    searchMode === 'search' && 'search-active'
+                    searchMode === "search" && "search-active"
                   }`}
-                  onClick={() => setSearchMode('search')}
+                  onClick={() => setSearchMode("search")}
                 >
                   <FileSearch />
                 </div>
                 <div
                   className={`panel__header--mode-item ${
-                    searchMode === 'chatbot' && 'chatbot-active'
+                    searchMode === "chatbot" && "chatbot-active"
                   }`}
-                  onClick={() => setSearchMode('chatbot')}
+                  onClick={() => setSearchMode("chatbot")}
                 >
                   <BotMessageSquare />
                 </div>
               </div>
               <div className="panel__header--info">
-                <p>{formatDateTime('day')}</p>
-                <p>{formatDateTime('month')}</p>
-                <p>{formatDateTime('hour')}</p>
+                <p>{formatDateTime("day")}</p>
+                <p>{formatDateTime("month")}</p>
+                <p>{formatDateTime("hour")}</p>
                 <Cog
                   className="panel__header--info-config"
                   onClick={() => {
-                    setViewSidebar(true)
-                    setSidebarSearchMode(false)
+                    setViewSidebar(true);
+                    setSidebarSearchMode(false);
                   }}
                 />
               </div>
             </div>
-            {searchMode === 'search' ? (
+            {searchMode === "search" ? (
               <PanelSearch
                 formatDateTime={(type: string) => formatDateTime(type)}
                 setSidebarSearchMode={(type: boolean) =>
@@ -156,5 +193,5 @@ export const PanelCard = () => {
         </div>
       </div>
     </>
-  )
-}
+  );
+};

--- a/front-end/src/index.css
+++ b/front-end/src/index.css
@@ -372,6 +372,92 @@ body.light-theme .side-bar__menu--items:hover {
   align-items: center;
 }
 
+.config-menu {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  font-family: var(--font);
+  padding-left: 30px;
+}
+
+.config-menu__input-wraper {
+  margin-top: 20px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  position: relative;
+}
+
+.config-menu__input-wraper label {
+  color: white;
+  font-size: 10px;
+  cursor: pointer;
+}
+
+.radio-input {
+  appearance: none;
+  -webkit-appearance: none;
+  background-color: transparent;
+  border: 2px solid #ccc;
+  border-radius: 50%;
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+  position: relative;
+  transition: border 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+}
+
+.radio-input::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 8px;
+  height: 8px;
+  background-color: #41469a;
+  border-radius: 50%;
+  transform: translate(-50%, -50%) scale(0);
+  transition: transform 0.2s ease-in-out;
+}
+
+.radio-input:checked {
+  border-color: rgb(68, 72, 157);
+  box-shadow: 0 0 0 3px rgba(65, 70, 154, 0.2);
+}
+
+.radio-input:checked::before {
+  transform: translate(-50%, -50%) scale(1);
+}
+
+.radio-input:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 4px rgba(65, 70, 154, 0.4);
+}
+
+body.light-theme .config-menu__input-wraper label {
+  color: black;
+}
+
+.config-menu h3 {
+  font-size: 13px;
+  font-weight: 400;
+}
+
+.config-menu__save {
+  margin-top: 20px;
+  width: 30%;
+  padding: 2px;
+  border-radius: 10px;
+  border: none;
+  background-color: #41469a;
+  color: white;
+  cursor: pointer;
+}
+
+.config-menu__save:hover {
+  background-color: rgb(76, 81, 180);
+}
+
 body.light-theme .panel__side-bar--header {
   color: #2f2e35;
 }


### PR DESCRIPTION
What I did:

Added an arrow-down icon to the search menu that toggles an expandable section.

Inside the expanded section, added radio buttons allowing the user to select the preferred redirect behavior when performing a search:

Stay on the same page

Navigate to a dedicated results page

Currently implemented on the frontend only; backend logic is not yet wired.

Why I did it:

To give users more control over the search behavior and improve the user experience by offering configuration options.