### PR TITLE
feat(shortcuts): integrate backend APIs to get, add, and remove user …

### DIFF
--- a/front-end/src/api-client/shortcut.ts
+++ b/front-end/src/api-client/shortcut.ts
@@ -1,0 +1,34 @@
+import { API } from "./api";
+
+export const getShortcuts = async (shortcuts: number[] | undefined) => {
+  if (!shortcuts) return;
+  const promises = shortcuts.map(id => API.get(`/wikipedia/${id}`));
+  const responses = await Promise.all(promises);
+  return responses.map(response => response.data);
+};
+
+export const addToShortcuts = async (documentId: number) => {
+  const payload = {
+    quickAccess: documentId,
+    type: "add"
+  };
+
+  try {
+    return await API.patch("/users/me/shortcuts", payload);
+  } catch (error) {
+    console.error("DIRECT FETCH ERROR:", error);
+  }
+};
+
+export const removeFromShortcuts = async (documentId: string) => {
+  const payload = {
+    quickAccess: parseInt(documentId),
+    type: "remove"
+  };
+
+  try {
+    return await API.patch("/users/me/shortcuts", payload);
+  } catch (error) {
+    console.error("DIRECT FETCH ERROR:", error);
+  }
+};

--- a/front-end/src/components/PanelSearch.tsx
+++ b/front-end/src/components/PanelSearch.tsx
@@ -9,6 +9,7 @@ import { getFavorites, removeFromFavorites } from "../api-client/favorite";
 import type { User } from "../api-client/auth";
 import { getUser } from "../api-client/user";
 import { SidebarPanelSearch } from "./SidebarPanelSearch";
+import { getShortcuts, removeFromShortcuts } from "../api-client/shortcut";
 
 type PanelSearchProps = {
   sidebarSearchMode: boolean;
@@ -24,6 +25,7 @@ export const PanelSearch = ({
   setViewSidebar
 }: PanelSearchProps) => {
   const [favorites, setFavorites] = useState<Result[]>([]);
+  const [shortcuts, setShortcuts] = useState<Result[]>([]);
   const [user, setUser] = useState<User>();
   const [mode, setMode] = useState<
     "History" | "Favorites" | "Shortcuts" | "Edit" | "Folders" | "Menu"
@@ -41,6 +43,15 @@ export const PanelSearch = ({
             userData.config.favorite
           );
           setFavorites(favoritesResponse || []);
+        } else {
+          setFavorites([]);
+        }
+
+        if (userData?.config?.quickAccess?.length) {
+          const shortcutsResponse = await getShortcuts(
+            userData.config.quickAccess
+          );
+          setShortcuts(shortcutsResponse || []);
         } else {
           setFavorites([]);
         }
@@ -73,6 +84,28 @@ export const PanelSearch = ({
       console.error("Failed to remove favorite:", error);
     }
   };
+  const handleRemoveFromShortcuts = async (documentId: number) => {
+    const id = documentId.toString();
+    try {
+      await removeFromShortcuts(id);
+      setShortcuts(prevShortcuts =>
+        prevShortcuts.filter(item => item._id !== documentId)
+      );
+      if (user) {
+        setUser({
+          ...user,
+          config: {
+            ...user.config,
+            quickAccess: user.config.quickAccess.filter(
+              short => short !== parseInt(id)
+            )
+          }
+        });
+      }
+    } catch (error) {
+      console.error("Failed to remove shortcuts:", error);
+    }
+  };
 
   return (
     <>
@@ -102,7 +135,9 @@ export const PanelSearch = ({
                   | "Menu"
               ) => setMode(item)}
               favorites={favorites}
+              shortcuts={shortcuts}
               removeFromFavorites={handleRemoveFromFavorite}
+              removeFromShortcuts={handleRemoveFromShortcuts}
             />
           </div>
         </div>
@@ -161,30 +196,35 @@ export const PanelSearch = ({
         <SearchBar />
 
         <div className="panel__shortcuts">
-          <div className="panel__shortcuts--card">
-            <img src={wiki_icon} alt="Article Image" width={40} height={37} />
-            <p>Mathematics in Nature</p>
-          </div>
-          <div className="panel__shortcuts--card">
-            <img src={wiki_icon} alt="Article Image" width={40} height={37} />
-            <p>Complex Numbers</p>
-          </div>
-          <div className="panel__shortcuts--card">
-            <img src={wiki_icon} alt="Article Image" width={40} height={37} />
-            <p>Complex Numbers</p>
-          </div>
-          <div className="panel__shortcuts--card">
-            <img src={wiki_icon} alt="Article Image" width={40} height={37} />
-            <p>Complex Numbers</p>
-          </div>
-          <div className="panel__shortcuts--card">
-            <img src={wiki_icon} alt="Article Image" width={40} height={37} />
-            <p>Complex Numbers</p>
-          </div>
-          <div className="panel__shortcuts--card">
-            <img src={wiki_icon} alt="Article Image" width={40} height={37} />
-            <p>Complex Numbers</p>
-          </div>
+          {shortcuts.slice(0, 6).map(item => (
+            <div className="panel__shortcuts--card">
+              <div className="shortcuts__card--header">
+                <X
+                  size={15}
+                  className="remove-favorites"
+                  onClick={() => handleRemoveFromShortcuts(item._id)}
+                />
+              </div>
+              <Link to={`/wiki/${item.title}`}>
+                <img
+                  src={wiki_icon}
+                  alt="Article Image"
+                  width={40}
+                  height={37}
+                />
+                <p>{item.title.substring(0, 7) + "..."}</p>
+              </Link>
+            </div>
+          ))}
+          <p
+            className="shor-more"
+            onClick={() => {
+              setMode("Shortcuts");
+              setSidebarSearchMode(true);
+            }}
+          >
+            {shortcuts.length > 6 && <p>ver mais</p>}
+          </p>
         </div>
       </div>
     </>

--- a/front-end/src/components/SidebarPanelSearch.tsx
+++ b/front-end/src/components/SidebarPanelSearch.tsx
@@ -16,6 +16,8 @@ type SidebarPanelSearchProps = {
     item: "History" | "Favorites" | "Shortcuts" | "Edit" | "Folders" | "Menu"
   ) => void;
   favorites: Result[];
+  shortcuts: Result[];
+  removeFromShortcuts: (documentId: number) => void;
   removeFromFavorites: (documentId: number) => void;
 };
 
@@ -23,7 +25,9 @@ export const SidebarPanelSearch = ({
   mode,
   favorites,
   setMode,
-  removeFromFavorites
+  removeFromFavorites,
+  shortcuts,
+  removeFromShortcuts
 }: SidebarPanelSearchProps) => {
   return (
     <>
@@ -83,7 +87,18 @@ export const SidebarPanelSearch = ({
           ))}
         </>
       ) : mode === "Shortcuts" ? (
-        <></>
+        <>
+          {shortcuts.map(item => (
+            <div className="side-bar__panel-card--menu-item">
+              <p>{item.title}</p>
+              <XCircle
+                onClick={() => removeFromShortcuts(item._id)}
+                className="remove-icon"
+                size={18}
+              />
+            </div>
+          ))}
+        </>
       ) : mode === "Edit" ? (
         <></>
       ) : (

--- a/front-end/src/index.css
+++ b/front-end/src/index.css
@@ -333,6 +333,7 @@ body.light-theme .side-bar__panel-card--menu-item:hover {
   background: none;
   color: white;
   border: none;
+  cursor: pointer;
 }
 
 body.light-theme .menu-button {
@@ -823,7 +824,7 @@ body.light-theme input:-webkit-autofill:focus {
 }
 
 .panel__shortcuts--card {
-  padding: 20px;
+  padding: 15px 20px 20px 20px;
   border-radius: 20px;
   border: var(--border-dark);
   width: 60px;
@@ -857,6 +858,12 @@ body.light-theme .panel__shortcuts--card p {
   background: none;
   -webkit-background-clip: initial;
   -webkit-text-fill-color: initial;
+}
+
+.shortcuts__card--header {
+  width: 122%;
+  display: flex;
+  justify-content: flex-end;
 }
 
 /* Panel ChatBot */

--- a/front-end/src/pages/WikiViewer.tsx
+++ b/front-end/src/pages/WikiViewer.tsx
@@ -5,6 +5,7 @@ import { addNumViewDoc } from "../api-client/elastic";
 import { Loading } from "../components/Loading";
 import { SearchBar } from "../components/SearchBar";
 import { addToFavorites } from "../api-client/favorite";
+import { addToShortcuts } from "../api-client/shortcut";
 
 export const WikiViewer = () => {
   const location = useLocation();
@@ -16,6 +17,14 @@ export const WikiViewer = () => {
   const handleAddFavorite = async () => {
     try {
       await addToFavorites(parseInt(documentId));
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  const handleAddShortcuts = async () => {
+    try {
+      await addToShortcuts(parseInt(documentId));
     } catch (error) {
       console.error(error);
     }
@@ -71,7 +80,9 @@ export const WikiViewer = () => {
                 <h2>{title.replace(/_/g, " ")}</h2>
                 <div className="wiki__header--menu">
                   <ScrollText className="menu-item" />
-                  <Route className="menu-item" />
+                  <button className="menu-button" onClick={handleAddShortcuts}>
+                    <Route className="menu-item" />
+                  </button>
                   <button className="menu-button" onClick={handleAddFavorite}>
                     <Star className="menu-item" />
                   </button>


### PR DESCRIPTION
This PR integrates the backend API for managing user shortcuts (get, add, remove). Users can now:
- View their saved shortcuts
- Add a shortcut via the initial card or PanelCard
- Remove a shortcut directly from the menu or card interface

All shortcut operations are now synced with the backend and reflect in the UI in real time.