### PR TITLE
feat: connect search result display preference to backend for persist…

### DIFF
--- a/back-end/api.http
+++ b/back-end/api.http
@@ -137,7 +137,7 @@ Content-Type: application/json
 ###
 
 GET http://localhost:3333/users/me/general-settings
-Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImFkbWluMiIsImlkIjoiNjgzODY4YWJlNDRkM2UzNjk1M2U4NmJkIiwiaWF0IjoxNzQ5NDc4MTQ3LCJleHAiOjE3NDk0NzgzMjd9.reqi-kPIanNruZaiSCYFo3Zt497sqHgFtR_X7gzPMS0
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6ImFkbWluMzQiLCJpZCI6IjY4NGI2ZWY3NDhmMmE1N2ExMjBmZTAyYiIsImlhdCI6MTc1MTU4ODc5NCwiZXhwIjoxNzUxNTkxMTk0fQ.VK50oUces2etWiPl3RADeiNj_Ck6K9OnM6tBFS7wl78
 
 ###
 PATCH http://localhost:3333/users/me/general-settings

--- a/front-end/src/api-client/general-settings.ts
+++ b/front-end/src/api-client/general-settings.ts
@@ -6,6 +6,12 @@ type UpdateGeneralSettings = {
   outputMethod?: string;
 };
 
+export type GeneralSettings = {
+  backgroundImage: string;
+  themeColor: string;
+  outputMethod: string;
+};
+
 export const getGeneralSettings = async () => {
   return API.get(`/users/me/general-settings`);
 };

--- a/front-end/src/components/PanelCard.tsx
+++ b/front-end/src/components/PanelCard.tsx
@@ -17,6 +17,7 @@ export const PanelCard = () => {
   const [viewSidebar, setViewSidebar] = useState(false);
   const [sidebarSearchMode, setSidebarSearchMode] = useState(false);
   const { isLight } = useContext(ThemeContext);
+  const { outputMethod } = useUser();
   const [searchMode, setSearchMode] = useState<"search" | "chatbot" | "result">(
     "search"
   );

--- a/front-end/src/components/Sidebar.tsx
+++ b/front-end/src/components/Sidebar.tsx
@@ -1,5 +1,10 @@
 import { X, ImagePlus, MonitorCog, ChevronDown, ChevronUp } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import {
+  getGeneralSettings,
+  updateGeneralSettings
+} from "../api-client/general-settings";
+import { useUser } from "../context/UserContex";
 
 type MenuSidebarProps = {
   viewSidebar: boolean;
@@ -13,6 +18,22 @@ export const MenuSidebar = ({
   setPanel
 }: MenuSidebarProps) => {
   const [configs, setConfigs] = useState(true);
+
+  const { outputMethod, setOutputMethod } = useUser();
+
+  const handleSave = async () => {
+    await updateGeneralSettings({
+      outputMethod: outputMethod
+    });
+  };
+
+  useEffect(() => {
+    const fetchGeneralSettings = async () => {
+      const data = await getGeneralSettings();
+      setOutputMethod(data.data.outputMethod || "sameScreen");
+    };
+    fetchGeneralSettings();
+  }, []);
 
   return (
     <div className={`${viewSidebar && "sidebar-blur__active"}`}>
@@ -56,24 +77,30 @@ export const MenuSidebar = ({
             <div className="config-menu__input-wraper">
               <input
                 type="radio"
-                id="inline-cards"
+                id="sameScreen"
                 value="inline"
                 name="results-location"
                 className="radio-input"
+                checked={outputMethod === "sameScreen"}
+                onChange={() => setOutputMethod("sameScreen")}
               />
-              <label htmlFor="inline-cards">Inline cards</label>
+              <label htmlFor="sameScreen">Inline cards</label>
             </div>
             <div className="config-menu__input-wraper">
               <input
                 type="radio"
-                id="results-page"
+                id="diffScreen"
                 value="page"
                 name="results-location"
                 className="radio-input"
+                checked={outputMethod === "diffScreen"}
+                onChange={() => setOutputMethod("diffScreen")}
               />
-              <label htmlFor="results-page">Dedicated results page</label>
+              <label htmlFor="diffScren">Dedicated results page</label>
             </div>
-            <button className="config-menu__save">Save</button>
+            <button className="config-menu__save" onClick={() => handleSave()}>
+              Save
+            </button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
What I did:

Connected the frontend radio inputs for search result display preference (same page vs. separate page) to the backend.

Now, the application:

Fetches the user’s current preference from the database on load.

Saves any changes to the backend when the user selects a different option.

Why I did it:

To persist user preferences regarding search result display, allowing a personalized and consistent experience across sessions and devices.

How to test it:

Log in with a user that has access to the search menu.

Select either "same page" or "separate page" as the search result mode.

Confirm that the preference is:

Saved to the backend correctly.

Fetched and reflected when the user reloads or revisits the page.