### PR TITLE
fix(search): display search results correctly when using same-page op…

### DIFF
--- a/front-end/src/components/PanelCard.tsx
+++ b/front-end/src/components/PanelCard.tsx
@@ -17,7 +17,6 @@ export const PanelCard = () => {
   const [viewSidebar, setViewSidebar] = useState(false);
   const [sidebarSearchMode, setSidebarSearchMode] = useState(false);
   const { isLight } = useContext(ThemeContext);
-  const { outputMethod } = useUser();
   const [searchMode, setSearchMode] = useState<"search" | "chatbot" | "result">(
     "search"
   );

--- a/front-end/src/components/ResultComponent.tsx
+++ b/front-end/src/components/ResultComponent.tsx
@@ -21,6 +21,7 @@ export const ResultComponent = ({ query }: ResultComponentProps) => {
   const [total, setTotal] = useState(0);
 
   useEffect(() => {
+    console.log(query);
     const fetchDocuments = async () => {
       const response = await searchDocs(query, page, 10);
       setResults(response.results);

--- a/front-end/src/components/SearchBar.tsx
+++ b/front-end/src/components/SearchBar.tsx
@@ -5,7 +5,7 @@ import { useUser } from "../context/UserContex";
 import { useQuery } from "../context/Query";
 
 type SearchBarProps = {
-  setSearchMode: () => void;
+  setSearchMode?: () => void;
 };
 
 export const SearchBar = ({ setSearchMode }: SearchBarProps) => {
@@ -22,6 +22,7 @@ export const SearchBar = ({ setSearchMode }: SearchBarProps) => {
       // Redireciona para a página de resultados, enviando os dados
       navigate(`/search?query=${encodeURIComponent(input)}&page=1&pageSize=10`);
     } else {
+      if (!setSearchMode) return;
       setSearchMode();
     }
   };

--- a/front-end/src/context/Query.tsx
+++ b/front-end/src/context/Query.tsx
@@ -15,7 +15,7 @@ export const QueryContext = createContext<QueryContextType>({
 // Hook personalizado para usar o contexto
 export const useQuery = () => useContext(QueryContext);
 
-export function UserProvider({ children }: { children: ReactNode }) {
+export function QueryProvider({ children }: { children: ReactNode }) {
   const [query, setQuery] = useState("");
 
   const value = {

--- a/front-end/src/main.tsx
+++ b/front-end/src/main.tsx
@@ -6,6 +6,7 @@ import { ThemeProvider } from "./context/ThemeContext.tsx";
 import { Footer } from "./components/Footer.tsx";
 import { BrowserRouter, useLocation } from "react-router-dom";
 import { UserProvider } from "./context/UserContex.tsx";
+import { QueryProvider } from "./context/Query.tsx";
 
 function LayoutWrapper() {
   const location = useLocation();
@@ -24,9 +25,11 @@ createRoot(document.getElementById("root")!).render(
   <>
     <BrowserRouter>
       <UserProvider>
-        <ThemeProvider>
-          <LayoutWrapper />
-        </ThemeProvider>
+        <QueryProvider>
+          <ThemeProvider>
+            <LayoutWrapper />
+          </ThemeProvider>
+        </QueryProvider>
       </UserProvider>
     </BrowserRouter>
   </>


### PR DESCRIPTION
What I did:

Fixed a bug where search results were not appearing when the user selected the option to stay on the same page.

Adjusted the rendering logic to ensure that the results section is properly updated after a search when using inline display mode.

Why I did it:

To ensure consistent and expected behavior across both redirect modes (same page and separate page). Users should always see search results regardless of the display method.